### PR TITLE
Use LS enable tester from active language server provider

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/clangd/CProjectChangeMonitor.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/clangd/CProjectChangeMonitor.java
@@ -14,16 +14,17 @@
 package org.eclipse.cdt.lsp.editor.ui.clangd;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.settings.model.CProjectDescriptionEvent;
 import org.eclipse.cdt.core.settings.model.ICConfigurationDescription;
 import org.eclipse.cdt.core.settings.model.ICProjectDescription;
 import org.eclipse.cdt.core.settings.model.ICProjectDescriptionListener;
+import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.cdt.lsp.LspUtils;
 import org.eclipse.cdt.lsp.editor.ui.LspEditorUiMessages;
 import org.eclipse.cdt.lsp.editor.ui.LspEditorUiPlugin;
-import org.eclipse.cdt.lsp.editor.ui.preference.LspEditorPreferencesTester;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -39,7 +40,8 @@ public class CProjectChangeMonitor {
 			ICProjectDescription newCProjectDecription = event.getNewCProjectDescription();
 			if (newCProjectDecription != null) {
 				IProject project = event.getProject();
-				if (project != null && LspEditorPreferencesTester.preferLspEditor(project)) {
+				boolean isEnabled = Optional.ofNullable(LspPlugin.getDefault()).map(LspPlugin::getCLanguageServerProvider).map(provider -> provider.isEnabledFor(project)).orElse(Boolean.FALSE);
+				if (project != null && isEnabled) {
 					ICConfigurationDescription newConfig = newCProjectDecription.getDefaultSettingConfiguration();
 					var cwdBuilder = newConfig.getBuildSetting().getBuilderCWD();
 					if (cwdBuilder != null) {

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/preference/LspEditorPreferencesTester.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/preference/LspEditorPreferencesTester.java
@@ -72,11 +72,13 @@ public class LspEditorPreferencesTester extends PropertyTester {
 		} else if (receiver instanceof DocumentSymbolWithFile) {
 			// called to enable the LS based CSymbolsContentProvider:
 			return true;
+		} else if (receiver instanceof IProject) {
+			return preferLspEditor((IProject) receiver);
 		}
 		return false;
 	}
 
-	public static boolean preferLspEditor(IProject project) {
+	private static boolean preferLspEditor(IProject project) {
 		// check project properties:
 		PreferenceMetadata<Boolean> option = LspEditorPreferences.getPreferenceMetadata();
 		return Platform.getPreferencesService().getBoolean(LspEditorUiPlugin.PLUGIN_ID, option.identifer(),


### PR DESCRIPTION
In case the language server will be provided by a different plug-in, the enable check from that provider shall be used.