### PR TITLE
[#59] Add org.eclipse.cdt.lsp.repository to produce p2 artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
  <modules>
     <module>bundles</module>
     <module>features</module>
+    <module>releng/org.eclipse.cdt.lsp.repository</module>
     <module>releng/org.eclipse.cdt.lsp.target</module>
  </modules>
 </project>

--- a/releng/org.eclipse.cdt.lsp.repository/category.xml
+++ b/releng/org.eclipse.cdt.lsp.repository/category.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2023 ArSysOp
+ This program and the accompanying materials are made available under the
+ terms of the Eclipse Public License 2.0 which is available at
+ https://www.eclipse.org/legal/epl-2.0/.
+
+ SPDX-License-Identifier: EPL-2.0
+
+ Contributors:
+     ArSysOp - initial API and implementation
+-->
+<site>
+	<category-def
+		name="org.eclipse.cdt.lsp.category"
+		label="CDT LSP">
+		<description>
+			C/C++ Language Server Protocol Support 
+		</description>
+	</category-def>
+	<feature 
+		id="org.eclipse.cdt.lsp.feature">
+		<category name="org.eclipse.cdt.lsp.category" />
+	</feature>
+	<bundle id="org.yaml.snakeyaml" />
+	<bundle id="org.yaml.snakeyaml.source" />
+</site>


### PR DESCRIPTION
Added p2 repository manifest

Fixes https://github.com/eclipse-cdt/cdt-lsp/issues/59