### PR TITLE
Refactor LS enable

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/preference/LspEditorPreferencesTester.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/preference/LspEditorPreferencesTester.java
@@ -13,66 +13,19 @@
 
 package org.eclipse.cdt.lsp.editor.ui.preference;
 
-import java.net.URI;
-import java.util.Optional;
-
-import org.eclipse.cdt.core.model.ICProject;
-import org.eclipse.cdt.core.model.ITranslationUnit;
-import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.cdt.lsp.editor.ui.LspEditorUiPlugin;
 import org.eclipse.core.expressions.PropertyTester;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ProjectScope;
-import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.PreferenceMetadata;
-import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorReference;
-import org.eclipse.ui.IURIEditorInput;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.part.FileEditorInput;
 
 public class LspEditorPreferencesTester extends PropertyTester {
-	private static final String FILE_SCHEME = "file"; //$NON-NLS-1$
 	
 	@Override
 	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
-		if (receiver instanceof URI) {
-			// called from the language server enabler:
-			var uri = (URI) receiver;
-			var fileHandle = getFileHandle(uri);
-			if(fileHandle != null && fileHandle instanceof IResource) {
-				var resource = (IResource) fileHandle;
-				if (resource != null && resource.getProject() != null)
-					return preferLspEditor(resource.getProject());
-			}
-			// when resource == null it's an external file: Check if the file is already opened, if not check the active editor:
-			return isFileOpenedInLspEditor(uri);
-		} else if (receiver instanceof IEditorInput) {
-			// called to determine the default editor for the file:
-			var editorInput = (IEditorInput) receiver;
-			IResource resource = editorInput.getAdapter(IResource.class);
-			if(resource != null && resource.getProject() != null) {
-				return preferLspEditor(resource.getProject());
-			}
-			// When resource == null it's an external file: Check if the file is already opened, if not check the active editor:
-			return isFileOpenedInLspEditor(editorInput);
-		} else if (receiver instanceof ITranslationUnit) {
-			// called to enable the LS based CSymbolsContentProvider: 
-			return Optional.of((ITranslationUnit) receiver)
-					 .map(ITranslationUnit::getCProject)
-					 .map(ICProject::getProject)
-					 .map(LspEditorPreferencesTester::preferLspEditor)
-					 .orElse(Boolean.FALSE);
-		} else if (receiver instanceof DocumentSymbolWithFile) {
-			// called to enable the LS based CSymbolsContentProvider:
-			return true;
-		} else if (receiver instanceof IProject) {
+		if (receiver instanceof IProject) {
 			return preferLspEditor((IProject) receiver);
 		}
 		return false;
@@ -83,96 +36,6 @@ public class LspEditorPreferencesTester extends PropertyTester {
 		PreferenceMetadata<Boolean> option = LspEditorPreferences.getPreferenceMetadata();
 		return Platform.getPreferencesService().getBoolean(LspEditorUiPlugin.PLUGIN_ID, option.identifer(),
 				option.defaultValue(), new IScopeContext[] { new ProjectScope(project) });
-	}
-	
-	private boolean isLspEditorActive() {
-		var activeWorkbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		if (activeWorkbenchWindow != null && activeWorkbenchWindow.getActivePage() != null) {
-			var activeEditor = activeWorkbenchWindow.getActivePage().getActiveEditor();
-			if (activeEditor != null) {
-				return LspPlugin.LSP_C_EDITOR_ID.equals(activeEditor.getEditorSite().getId());
-			}
-		}
-		return false;
-	}
-	
-	private IFile getFileHandle(URI uri) {
-		if (uri == null) {
-			return null;
-		}
-		if (FILE_SCHEME.equals(uri.getScheme())) {
-			IFile[] files = LspEditorUiPlugin.getDefault().getWorkspace().getRoot().findFilesForLocationURI(uri);
-			if (files.length > 0) {
-				return files[0];
-			}
-			return null;
-		} else {
-			return Adapters.adapt(uri.toString(), IFile.class, true);
-		}
-	}
-	
-	private boolean isFileOpenedInLspEditor(URI uri) {
-		if (uri == null) {
-			return false;
-		}
-		var activeEditors = getActiveEditors();
-		if (activeEditors != null) {
-			for (IEditorReference editor : activeEditors) {
-				IEditorInput editorInput = null;
-				URI editorUnputURI = null;
-				try {
-					editorInput = editor.getEditorInput();
-				} catch (PartInitException e) {
-					LspEditorUiPlugin.logError(e.getMessage(), e);
-					continue;
-				}
-				
-				if (editorInput instanceof IURIEditorInput) {
-					editorUnputURI = ((IURIEditorInput) editorInput).getURI();
-				} else if (editorInput instanceof FileEditorInput) {
-					editorUnputURI = ((FileEditorInput) editorInput).getFile().getLocationURI();
-				}
-
-				if (uri.equals(editorUnputURI)) {
-					// should return false when an external header file with same URI is opened in a LSP editor 
-					// and non LSP editor and tab switching from a non LSP editor to the tab with the file in the non LSP editor:
-					return LspPlugin.LSP_C_EDITOR_ID.equals(editor.getEditor(true).getEditorSite().getId()) && isLspEditorActive();
-				}
-			}
-		}
-		// the file has not been opened yet -> goto definition/declaration case
-		return isLspEditorActive();
-	}
-	
-	private boolean isFileOpenedInLspEditor(IEditorInput editorInput) {
-	if (editorInput == null) {
-		return false;
-	}
-	var activeEditors = getActiveEditors();
-	if (activeEditors != null) {
-		for (IEditorReference editor : activeEditors) {
-			IEditorInput editorInputFromEditor = null;
-			try {
-				editorInputFromEditor = editor.getEditorInput();
-			} catch (PartInitException e) {
-				LspEditorUiPlugin.logError(e.getMessage(), e);
-				continue;
-			}
-			if (editorInput.equals(editorInputFromEditor)) {
-				return LspPlugin.LSP_C_EDITOR_ID.equals(editor.getEditor(true).getEditorSite().getId());
-			}
-		}
-	}
-	// the file has not been opened yet:
-	return isLspEditorActive();
-}
-	
-	private IEditorReference[] getActiveEditors() {
-		var activeWorkbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		if (activeWorkbenchWindow != null && activeWorkbenchWindow.getActivePage() != null) {
-			return activeWorkbenchWindow.getActivePage().getEditorReferences();
-		}
-		return null;
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/LspUtilsTest.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/LspUtilsTest.java
@@ -1,6 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bachmann electronic GmbH and others.
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ *******************************************************************************/
+
 package org.eclipse.cdt.lsp.test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.lsp.LspUtils;

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/TestUtils.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/TestUtils.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bachmann electronic GmbH and others.
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.cdt.lsp.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+import org.junit.jupiter.api.TestInfo;
+
+public class TestUtils {
+		
+	public static IProject createCProject(String projectName) throws CoreException {
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+		if (project.exists()) {
+			return project;
+		}
+		project.create(null);
+		project.open(null);
+		// configure C nature
+		IProjectDescription description = project.getDescription();
+		if (description != null) {
+			String[] natureIds = {"org.eclipse.cdt.core.cnature"};
+			description.setNatureIds(natureIds);
+			project.setDescription(description, null);
+		}
+		return project;
+	}
+	
+	public static void deleteProject(IProject project) throws CoreException {
+		if (project != null) {
+			project.delete(true, new NullProgressMonitor());
+		}
+	}
+	
+	public static String getName(TestInfo testInfo) {
+		String displayName = testInfo.getDisplayName();
+		String replaceFirst = displayName.replaceFirst("\\(.*\\)", "");
+		return replaceFirst;
+	}
+	
+	public static IEditorPart openInEditor(URI uri, String editorID) throws PartInitException {
+		IEditorPart part = IDE.openEditor(getWorkbenchPage(), uri, editorID, true);		
+		part.setFocus();
+		return part;
+	}
+	
+	public static IEditorPart openInEditor(IFile file) throws PartInitException {
+		IEditorPart part = IDE.openEditor(getWorkbenchPage(), file);
+		part.setFocus();
+		return part;
+	}
+	
+	public static boolean closeEditor(IEditorPart editor, boolean save) {
+		IWorkbenchWindow workbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchPage page = workbenchWindow.getActivePage();
+		return page.closeEditor(editor, save);
+	}
+	
+	public static IFile createFile(IProject p, String name, String content) throws CoreException, UnsupportedEncodingException {
+		IFile testFile = p.getFile(name);
+		testFile.create(new ByteArrayInputStream(content.getBytes(testFile.getCharset())), true, null);
+		return testFile;
+	}
+	
+	private static IWorkbenchPage getWorkbenchPage() {
+		return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/server/enable/HasLanguageServerPropertyTesterTest.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/server/enable/HasLanguageServerPropertyTesterTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bachmann electronic GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.cdt.lsp.test.server.enable;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.cdt.lsp.LspPlugin;
+import org.eclipse.cdt.lsp.server.enable.HasLanguageServerPropertyTester;
+import org.eclipse.cdt.lsp.test.TestUtils;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ui.IEditorPart;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
+
+class HasLanguageServerPropertyTesterTest {
+	private static final String EXTERNAL_HEADER_HPP = "ExternalHeader.hpp";
+	private IProject project;
+	private File externalFile;
+	private IEditorPart editor;
+	
+	@TempDir
+	private static File TEMP_DIR;
+	
+	@BeforeEach
+	public void setUp(TestInfo testInfo) throws CoreException {
+		project = TestUtils.createCProject(TestUtils.getName(testInfo));
+	}
+	
+	@AfterEach
+	public void cleanUp() throws CoreException {
+		TestUtils.deleteProject(project);
+		if (externalFile != null) {
+			externalFile.delete();
+		}
+		if (editor != null) {
+			TestUtils.closeEditor(editor, false);
+		}
+	}
+
+	/**
+	 * Tests whether LS enable test returns false for an external file when no (LSP) editor is opened.
+	 * @throws IOException 
+	 */
+	@Test
+	public void testLsNotEnabledForExternalFile_NoEditorOpen() throws CoreException, IOException {
+		//GIVEN is an external file which is not opened:
+		externalFile = new File(TEMP_DIR, EXTERNAL_HEADER_HPP);
+		//WHEN the file is not opened,
+		//THEN the hasLanguageServerPropertyTester.test returns FALSE for the given file URI:
+		assertFalse(new HasLanguageServerPropertyTester().test(externalFile.toURI(), null, null, null));	
+	}
+	
+	/**
+	 * Tests whether LS enable test returns false for an external file which is opened in the C/C++ Editor.
+	 */	
+	@Test
+	public void testLsNotEnabledForExternalFile_OpenedInCEditor() throws CoreException, IOException {
+		//GIVEN is an existing external file:
+		externalFile = new File(TEMP_DIR, EXTERNAL_HEADER_HPP);
+		externalFile.createNewFile();
+		//WHEN it's opened in the C/C++ Editor:
+		editor = TestUtils.openInEditor(externalFile.toURI(), LspPlugin.C_EDITOR_ID);
+		//THEN the hasLanguageServerPropertyTester.test returns FALSE for the given file URI:
+		assertFalse(new HasLanguageServerPropertyTester().test(externalFile.toURI(), null, null, null));
+	}
+	
+	/**
+	 * Tests whether LS enable test returns true for an external file which is opened in the C/C++ Editor (LSP).
+	 */	
+	@Test
+	public void testLsEnableForExternalFile_OpenedInLspCEditor() throws CoreException, IOException {
+		//GIVEN is an existing external file:
+		externalFile = new File(TEMP_DIR, EXTERNAL_HEADER_HPP);
+		externalFile.createNewFile();
+		//WHEN it's opened in the LSP based C/C++ Editor:
+		editor = TestUtils.openInEditor(externalFile.toURI(), LspPlugin.LSP_C_EDITOR_ID);
+		//THEN the hasLanguageServerPropertyTester.test returns TRUE for the given file URI:
+		assertTrue(new HasLanguageServerPropertyTester().test(externalFile.toURI(), null, null, null));	
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.eclipse.cdt.lsp;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Export-Package: org.eclipse.cdt.lsp,
  org.eclipse.cdt.lsp.server,
+ org.eclipse.cdt.lsp.server.enable,
  org.eclipse.cdt.lsp.services
 Bundle-Activator: org.eclipse.cdt.lsp.LspPlugin
 Bundle-Vendor: Eclipse.org

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspPlugin.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspPlugin.java
@@ -14,8 +14,10 @@ package org.eclipse.cdt.lsp;
 
 import org.eclipse.cdt.lsp.internal.server.CLanguageServerRegistry;
 import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -31,6 +33,7 @@ public class LspPlugin extends AbstractUIPlugin {
 	private static LspPlugin plugin;
 	
 	private ICLanguageServerProvider cLanguageServerProvider;
+	private IWorkspace workspace;
 
 	/**
 	 * The constructor
@@ -42,6 +45,9 @@ public class LspPlugin extends AbstractUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
+		ServiceTracker<IWorkspace, IWorkspace> workspaceTracker = new ServiceTracker<>(context, IWorkspace.class, null);
+		workspaceTracker.open();
+		workspace = workspaceTracker.getService();
 		cLanguageServerProvider = new CLanguageServerRegistry().createCLanguageServerProvider();
 	}
 
@@ -58,6 +64,10 @@ public class LspPlugin extends AbstractUIPlugin {
 	 */
 	public static LspPlugin getDefault() {
 		return plugin;
+	}
+	
+	public IWorkspace getWorkspace() {
+		return workspace;
 	}
 	
 	public ICLanguageServerProvider getCLanguageServerProvider() {

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
@@ -1,11 +1,20 @@
 package org.eclipse.cdt.lsp;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IURIEditorInput;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.progress.UIJob;
 
 public class LspUtils {
@@ -45,6 +54,87 @@ public class LspUtils {
 		if (PlatformUI.getWorkbench() != null && PlatformUI.getWorkbench().getActiveWorkbenchWindow() != null)
 			return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
 		return null;
+	}
+	
+	public static boolean isFileOpenedInLspEditor(URI uri) {
+		if (uri == null) {
+			return false;
+		}
+		var editors = getEditors();
+		if (!editors.isEmpty()) {
+			for (IEditorReference editor : editors) {
+				IEditorInput editorInput = null;
+				URI editorUnputURI = null;
+				try {
+					editorInput = editor.getEditorInput();
+				} catch (PartInitException e) {
+					LspPlugin.logError(e.getMessage(), e);
+					continue;
+				}
+				
+				if (editorInput instanceof IURIEditorInput) {
+					editorUnputURI = ((IURIEditorInput) editorInput).getURI();
+				} else if (editorInput instanceof FileEditorInput) {
+					editorUnputURI = ((FileEditorInput) editorInput).getFile().getLocationURI();
+				}
+
+				if (uri.equals(editorUnputURI)) {
+					// should return false when an external header file with same URI is opened in a LSP editor 
+					// and non LSP editor and tab switching from a non LSP editor to the tab with the file in the non LSP editor:
+					return LspPlugin.LSP_C_EDITOR_ID.equals(editor.getEditor(true).getEditorSite().getId()) && isLspEditorActive();
+				}
+			}
+			// the file has not been opened yet -> goto definition/declaration case
+			return isLspEditorActive();
+		}
+		return false;
+	}
+	
+	public static boolean isFileOpenedInLspEditor(IEditorInput editorInput) {
+		if (editorInput == null) {
+			return false;
+		}
+		var editors = getEditors();
+		if (!editors.isEmpty()) {
+			for (IEditorReference editor : editors) {
+				IEditorInput editorInputFromEditor = null;
+				try {
+					editorInputFromEditor = editor.getEditorInput();
+				} catch (PartInitException e) {
+					LspPlugin.logError(e.getMessage(), e);
+					continue;
+				}
+				if (editorInput.equals(editorInputFromEditor)) {
+					return LspPlugin.LSP_C_EDITOR_ID.equals(editor.getEditor(true).getEditorSite().getId());
+				}
+			}
+			// the file has not been opened yet:
+			return isLspEditorActive();
+		}
+		return false;
+	}
+	
+	public static List<IEditorReference> getEditors() {
+		List<IEditorReference> editorsList = new ArrayList<>();
+		for (var window : PlatformUI.getWorkbench().getWorkbenchWindows()) {
+			for (var page : window.getPages()) {
+				for (var editor : page.getEditorReferences()) {
+					editorsList.add(editor);
+				}
+			}
+		}
+		return editorsList;
+	}
+	
+	private static boolean isLspEditorActive() {
+		var activeWorkbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (activeWorkbenchWindow != null && activeWorkbenchWindow.getActivePage() != null) {
+			var activeEditor = activeWorkbenchWindow.getActivePage().getActiveEditor();
+			if (activeEditor != null) {
+				return LspPlugin.LSP_C_EDITOR_ID.equals(activeEditor.getEditorSite().getId());
+			}
+		}
+		return false;
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/CEditorAssociationOverride.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/CEditorAssociationOverride.java
@@ -41,7 +41,7 @@ public class CEditorAssociationOverride implements IEditorAssociationOverride {
 		if (isNoCElement(contentType)) {
 			return editorDescriptors;
 		}
-		if (cLanguageServerProvider.isEnabledFor(editorInput)) {
+		if (isEnabledFor(editorInput)) {
 			return editorFilter(LspPlugin.C_EDITOR_ID, editorDescriptors); // remove CDT C-Editor
 		}
 		return editorFilter(LspPlugin.LSP_C_EDITOR_ID, editorDescriptors); // remove LSP based C-Editor
@@ -70,6 +70,15 @@ public class CEditorAssociationOverride implements IEditorAssociationOverride {
 		}
 		return editorDescriptor;
 	}
+	
+	private boolean isEnabledFor(IEditorInput editorInput) {
+		IResource resource = editorInput.getAdapter(IResource.class);
+		if (resource != null) {
+			return cLanguageServerProvider.isEnabledFor(resource.getProject());
+		}
+		// When resource == null it's an external file: Check if the file is already opened, if not check the active editor:
+		return LspUtils.isFileOpenedInLspEditor(editorInput);
+	}
 
 	private boolean isNoCElement(IContentType contentType) {
 		if (contentType == null) {
@@ -97,7 +106,7 @@ public class CEditorAssociationOverride implements IEditorAssociationOverride {
 		if (isNoCElement(contentType))
 			return null;
 
-		if (cLanguageServerProvider.isEnabledFor(editorInput)) {
+		if (isEnabledFor(editorInput)) {
 			return getEditorDescriptorById(editorInput.getName(), LspPlugin.LSP_C_EDITOR_ID, contentType); // return LSP based C/C++ Editor
 		} 
 		// TODO: return null; when either https://github.com/eclipse-cdt/cdt/pull/310 or 

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/DefaultCLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/DefaultCLanguageServerProvider.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.cdt.utils.PathUtil;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 
 public class DefaultCLanguageServerProvider implements ICLanguageServerProvider {
@@ -67,14 +68,14 @@ public class DefaultCLanguageServerProvider implements ICLanguageServerProvider 
 	}
 
 	@Override
-	public boolean isEnabledFor(Object document) {
-		// check if server has been found:
+	public boolean isEnabledFor(IProject project) {
+		// check if server has been defined:
 		if (getCommands().isEmpty()) {
 			return false;
 		}
 		// check if enable expression is defined:
 		if (enableExpression != null) {
-			return enableExpression.evaluate(document);
+			return enableExpression.evaluate(project);
 		}
 		//language server is always enabled when no enable expression has been defined in the extension point: 
 		return true;

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/ICLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/ICLanguageServerProvider.java
@@ -14,6 +14,8 @@ package org.eclipse.cdt.lsp.server;
 
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
+
 public interface ICLanguageServerProvider {
 
 	/**
@@ -23,10 +25,10 @@ public interface ICLanguageServerProvider {
 	 */
 	public List<String> getCommands();
 	
-	
 	/**
 	 * The command list includes the location of the language server followed by its calling arguments.
 	 * 
+	 * @param commands
 	 */
 	public void setCommands(List<String> commands);
 	
@@ -38,12 +40,11 @@ public interface ICLanguageServerProvider {
 	public void setEnableExpression(EnableExpression enableExpression);
 	
 	/**
-	 * Check whether the LSP based C/C++ Editor and the language server shall be used for the given object.
-	 * Should be checked by the {@link EnableExpression#evaluate(Object)} method.
+	 * Check whether the LSP based C/C++ Editor and the language server shall be used for the given project.
 	 * 
-	 * @param receiver object which should be opened by the LSP Editor with language server
-	 * @return true if LSP based C/C++ Editor and language server shall be enabled for the given object
+	 * @param project 
+	 * @return true if LSP based C/C++ Editor and language server shall be enabled for the given project, otherwise false.
 	 */
-	public boolean isEnabledFor(Object receiver);
+	public boolean isEnabledFor(IProject project);
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/enable/HasLanguageServerPropertyTester.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/enable/HasLanguageServerPropertyTester.java
@@ -12,9 +12,18 @@
 
 package org.eclipse.cdt.lsp.server.enable;
 
+import java.net.URI;
+import java.util.Optional;
+
+import org.eclipse.cdt.core.model.ICProject;
+import org.eclipse.cdt.core.model.ITranslationUnit;
 import org.eclipse.cdt.lsp.LspPlugin;
+import org.eclipse.cdt.lsp.LspUtils;
 import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
 import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
 
 public class HasLanguageServerPropertyTester extends PropertyTester {
 	private final ICLanguageServerProvider cLanguageServerProvider;
@@ -26,9 +35,33 @@ public class HasLanguageServerPropertyTester extends PropertyTester {
 	@Override
 	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
 		if (cLanguageServerProvider != null) {
-			return cLanguageServerProvider.isEnabledFor(receiver);
+			if (receiver instanceof URI) {
+				// called from the language server enabler for LSP4E:
+				var uri = (URI) receiver;
+				// when getProject is empty, it's an external file: Check if the file is already opened, if not check the active editor:
+				return getProject(uri).map(cLanguageServerProvider::isEnabledFor).orElse(LspUtils.isFileOpenedInLspEditor(uri));
+			} else if (receiver instanceof ITranslationUnit) {
+				// called to enable the LS based CSymbolsContentProvider: 
+				return Optional.of((ITranslationUnit) receiver)
+						 .map(ITranslationUnit::getCProject)
+						 .map(ICProject::getProject)
+						 .map(cLanguageServerProvider::isEnabledFor)
+						 .orElse(Boolean.FALSE);
+			} else if (receiver instanceof DocumentSymbolWithFile) {
+				// called to enable the LS based CSymbolsContentProvider:
+				return true;
+			}
+			return false;
 		}
-		return true;
+		return false;
+	}
+	
+	private Optional<IProject> getProject(URI uri) {
+		IFile[] files = LspPlugin.getDefault().getWorkspace().getRoot().findFilesForLocationURI(uri);
+		if (files.length > 0) {	
+			return Optional.ofNullable(files[0].getProject());
+		}
+		return Optional.empty();	
 	}
 
 }


### PR DESCRIPTION
Moved code from org.eclipse.cdt.lsp.editor.editor.ui to org.eclipse.cdt.lsp plug-in.
Reasons:
- The logic for the check whether to open a C/C++ source file in the LSP based editor or not should be done in the org.eclipse.cdt.lsp plug-in, since the org.eclipse.ui.ide.editorAssociationOverride extension point is here as well.

- The org.eclipse.cdt.lsp.editor.editor.ui has to check whether the prefer LSB Editor has been set in the project properties or not on a given project.

- Replaced argument type Object in ICLanguageServerProvider.isEnabledFor by IProject. This makes it clearly to implement a test.