### PR TITLE
[#65] Add "org.eclipse.cdt.lsp.clangd" bundle

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/.classpath
+++ b/bundles/org.eclipse.cdt.lsp.clangd/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/org.eclipse.cdt.lsp.clangd/.project
+++ b/bundles/org.eclipse.cdt.lsp.clangd/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.cdt.lsp.clangd</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.cdt.lsp.clangd
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: org.eclipse.cdt.lsp.clangd;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Name: %Bundle-Name
+Bundle-Vendor: %Bundle-Vendor
+Bundle-Copyright: %Bundle-Copyright
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.cdt.lsp;bundle-version="1.0.0"

--- a/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/l10n/bundle.properties
@@ -1,0 +1,24 @@
+#Properties file for org.eclipse.cdt.lsp.clangd
+###############################################################################
+# Copyright (c) 2023 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     ArSysOp - initial API and implementation
+###############################################################################
+
+Bundle-Vendor = Eclipse CDT
+Bundle-Name = Clangd Language Server Support
+Bundle-Copyright =\
+Copyright (c) 2023 ArSysOp and others.\n\
+\n\
+This program and the accompanying materials are made\n\
+available under the terms of the Eclipse Public License 2.0\n\
+which is available at https://www.eclipse.org/legal/epl-2.0/\n\
+\n\
+SPDX-License-Identifier: EPL-2.0\n\

--- a/bundles/org.eclipse.cdt.lsp.clangd/about.html
+++ b/bundles/org.eclipse.cdt.lsp.clangd/about.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+	<title>About</title>
+</head>
+
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="https://www.eclipse.org/legal/epl-2.0">https://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="https://www.eclipse.org/">https://www.eclipse.org</a>.
+	</p>
+
+</body>
+
+</html>

--- a/bundles/org.eclipse.cdt.lsp.clangd/build.properties
+++ b/bundles/org.eclipse.cdt.lsp.clangd/build.properties
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright (c) 2023 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     ArSysOp - initial API and implementation
+###############################################################################
+
+source.. = src/
+output.. = bin/
+bin.includes = .,\
+               about.html,\
+               META-INF/,\
+               OSGI-INF/

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/editor/.gitkeep
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/editor/.gitkeep
@@ -1,0 +1,1 @@
+Remove me after placing the useful file to this folder

--- a/features/org.eclipse.cdt.lsp.feature/feature.xml
+++ b/features/org.eclipse.cdt.lsp.feature/feature.xml
@@ -37,6 +37,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.cdt.lsp.clangd"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.cdt.lsp.editor.ui"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Added "org.eclipse.cdt.lsp.clangd" bundle as a placeholder for clangd-specific code

Fixes https://github.com/eclipse-cdt/cdt-lsp/issues/65