### PR TITLE
[#50] Refactor static log methods

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiPlugin.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiPlugin.java
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ * Alexander Fedorov (ArSysOp) - use Platform for logging
  *******************************************************************************/
 
 package org.eclipse.cdt.lsp.editor.ui;
@@ -77,10 +78,6 @@ public class LspEditorUiPlugin extends AbstractUIPlugin {
 			preferenceStore = new ScopedPreferenceStore(InstanceScope.INSTANCE, LspEditorUiPlugin.PLUGIN_ID);
 		}
 		return preferenceStore;
-	}
-	
-	public static void logError(String message, Throwable throwable) {
-		getDefault().getLog().error(message, throwable);
 	}
 	
 	public IWorkspace getWorkspace() {

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/clangd/CProjectChangeMonitor.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/clangd/CProjectChangeMonitor.java
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ * Alexander Fedorov (ArSysOp) - use Platform for logging
  *******************************************************************************/
 
 package org.eclipse.cdt.lsp.editor.ui.clangd;
@@ -28,6 +29,7 @@ import org.eclipse.cdt.lsp.editor.ui.LspEditorUiPlugin;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.yaml.snakeyaml.scanner.ScannerException;
 
@@ -57,8 +59,10 @@ public class CProjectChangeMonitor {
 								LspUtils.showErrorMessage(LspEditorUiMessages.CProjectChangeMonitor_yaml_scanner_error, 
 										LspEditorUiMessages.CProjectChangeMonitor_yaml_scanner_error_message + projectLocation + configFile , status);
 							}
-						} catch (CoreException | IOException e) {
-							LspEditorUiPlugin.logError(e.getMessage(), e);
+						} catch (CoreException e) {
+							Platform.getLog(getClass()).log(e.getStatus());
+						} catch (IOException e) {
+							Platform.getLog(getClass()).error(e.getMessage(), e);
 						}
 					}
 				}			

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspPlugin.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspPlugin.java
@@ -8,6 +8,7 @@
  * 
  * Contributors:
  * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ * Alexander Fedorov (ArSysOp) - use Platform for logging
  *******************************************************************************/
 
 package org.eclipse.cdt.lsp;
@@ -74,16 +75,4 @@ public class LspPlugin extends AbstractUIPlugin {
 		return cLanguageServerProvider;
 	}
 	
-	public static void logError(String message, Throwable throwable) {
-		getDefault().getLog().error(message, throwable);
-	}
-	
-	public static void logWarning(String message) {
-		getDefault().getLog().warn(message);
-	}
-	
-	public static void logWarning(String message, Throwable throwable) {
-		getDefault().getLog().warn(message, throwable);
-	}
-
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
 package org.eclipse.cdt.lsp;
 
 import java.net.URI;
@@ -6,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.swt.widgets.Shell;
@@ -68,7 +80,7 @@ public class LspUtils {
 				try {
 					editorInput = editor.getEditorInput();
 				} catch (PartInitException e) {
-					LspPlugin.logError(e.getMessage(), e);
+					Platform.getLog(LspUtils.class).error(e.getMessage(), e);
 					continue;
 				}
 				
@@ -101,7 +113,7 @@ public class LspUtils {
 				try {
 					editorInputFromEditor = editor.getEditorInput();
 				} catch (PartInitException e) {
-					LspPlugin.logError(e.getMessage(), e);
+					Platform.getLog(LspUtils.class).error(e.getMessage(), e);
 					continue;
 				}
 				if (editorInput.equals(editorInputFromEditor)) {

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/server/CLanguageServerRegistry.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/server/CLanguageServerRegistry.java
@@ -8,6 +8,7 @@
  * 
  * Contributors:
  * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ * Alexander Fedorov (ArSysOp) - use Platform for logging
  *******************************************************************************/
 
 package org.eclipse.cdt.lsp.internal.server;
@@ -69,7 +70,7 @@ public class CLanguageServerRegistry {
 									enableExpression = new EnableExpression(this::getEvaluationContext,
 											ExpressionConverter.getDefault().perform(enabledWhenChildren[0]));
 								} catch (CoreException e) {
-									LspPlugin.logWarning("Failed to create enable expression for " + configurationElement.getNamespaceIdentifier(), e);
+									Platform.getLog(getClass()).warn("Failed to create enable expression for " + configurationElement.getNamespaceIdentifier(), e);
 								}
 							}
 						}
@@ -81,7 +82,7 @@ public class CLanguageServerRegistry {
 			}
 		}
 		if (providers.isEmpty()) {
-			LspPlugin.logWarning("No C/C++ language server defined");
+			Platform.getLog(getClass()).warn("No C/C++ language server defined");
 			prioritizedProvider = new DefaultCLanguageServerProvider();
 		} else {
 			// get provider with highest priority:
@@ -105,7 +106,7 @@ public class CLanguageServerRegistry {
 			Object obj = configurationElement.createExecutableExtension(CLASS);
 			result = Adapters.adapt(obj, clazz);
 		} catch (CoreException e) {
-			LspPlugin.logError(e.getMessage(), e);
+			Platform.getLog(getClass()).log(e.getStatus());
 		}
 		return result;
 	}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/EnableExpression.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/EnableExpression.java
@@ -8,18 +8,19 @@
  * 
  * Contributors:
  * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ * Alexander Fedorov (ArSysOp) - use Platform for logging
  *******************************************************************************/
 
 package org.eclipse.cdt.lsp.server;
 
 import java.util.function.Supplier;
 
-import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.core.expressions.EvaluationContext;
 import org.eclipse.core.expressions.EvaluationResult;
 import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
 
 /**
  * Checks whether the LSP based C/C++ Editor and language server shall be enabled
@@ -48,7 +49,7 @@ public final class EnableExpression {
 			context.setAllowPluginActivation(true);
 			return cExpression.evaluate(context).equals(EvaluationResult.TRUE);
 		} catch (CoreException e) {
-			LspPlugin.logError("Error occured during evaluation of enablement expression", e); //$NON-NLS-1$
+			Platform.getLog(getClass()).log(e.getStatus());
 		}
 		return false;
 	}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/navigator/CSymbolsContentProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/navigator/CSymbolsContentProvider.java
@@ -8,6 +8,7 @@
  * 
  * Contributors:
  * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ * Alexander Fedorov (ArSysOp) - use Platform for logging
  *******************************************************************************/
 
 package org.eclipse.cdt.lsp.ui.navigator;
@@ -24,8 +25,8 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.cdt.core.model.CModelException;
 import org.eclipse.cdt.core.model.ITranslationUnit;
 import org.eclipse.cdt.internal.ui.navigator.CNavigatorContentProvider;
-import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerWrapper;
@@ -95,7 +96,7 @@ public class CSymbolsContentProvider extends CNavigatorContentProvider {
 						.map(s -> s.execute(ls -> ls.getTextDocumentService().documentSymbol(params)))
 						.orElse(CompletableFuture.completedFuture(null));
 			} catch (TimeoutException | ExecutionException | InterruptedException e) {
-				LspPlugin.logError(e.getMessage(), e);
+				Platform.getLog(getClass()).error(e.getMessage(), e);
 				symbols = CompletableFuture.completedFuture(null);
 				if (e instanceof InterruptedException) {
 					Thread.currentThread().interrupt();

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/navigator/CSymbolsOpenActionProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/navigator/CSymbolsOpenActionProvider.java
@@ -8,14 +8,15 @@
  * 
  * Contributors:
  * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ * Alexander Fedorov (ArSysOp) - use Platform for logging
  *******************************************************************************/
 
 package org.eclipse.cdt.lsp.ui.navigator;
 
 import org.eclipse.cdt.internal.ui.cview.CViewMessages;
-import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.text.BadLocationException;
@@ -56,7 +57,7 @@ public class CSymbolsOpenActionProvider extends CommonActionProvider {
 					part = IDE.openEditor(this.page, fOpenElement.file);
 					revealInEditor(part, fOpenElement);
 				} catch (CoreException exc) {
-					LspPlugin.logError(exc.getMessage(), exc);
+					Platform.getLog(getClass()).log(exc.getStatus());
 				}
 			}
 		}
@@ -91,7 +92,7 @@ public class CSymbolsOpenActionProvider extends CommonActionProvider {
 							+ range.getEnd().getCharacter();
 					((ITextEditor) part).selectAndReveal(startOffset, endOffset - startOffset);
 				} catch (BadLocationException exc) {
-					LspPlugin.logError(exc.getMessage(), exc);
+					Platform.getLog(getClass()).error(exc.getMessage(), exc);
 				}
 			}
 		}	


### PR DESCRIPTION
Switch to standard `Platform.getLog(Class<?>)`

Fixes https://github.com/eclipse-cdt/cdt-lsp/issues/50