### PR TITLE
[#70] Add hover provider for debugging

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.debug.ui,
  org.eclipse.lsp4j,
  org.eclipse.lsp4j.jsonrpc,
- org.eclipse.cdt.codan.core
+ org.eclipse.cdt.codan.core,
+ org.eclipse.cdt.debug.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.cdt.lsp
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -237,5 +237,15 @@
          </action>
       </editorContribution>
    </extension>
+   
+   <extension
+         point="org.eclipse.ui.genericeditor.hoverProviders">
+      <hoverProvider
+            class="org.eclipse.cdt.lsp.editor.DebugHoverProvider"
+            contentType="org.eclipse.core.runtime.text"
+            id="org.eclipse.cdt.lsp.editor.DebugHoverProvider"
+            isBefore="org.eclipse.lsp4e.operations.hover.LSPTextHover">
+      </hoverProvider>
+   </extension>
 </plugin>
 

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/DebugHoverProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/DebugHoverProvider.java
@@ -1,0 +1,48 @@
+package org.eclipse.cdt.lsp.editor;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.cdt.ui.text.c.hover.ICEditorTextHover;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.jface.text.IInformationControlCreator;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextHover;
+import org.eclipse.jface.text.ITextHoverExtension;
+import org.eclipse.jface.text.ITextHoverExtension2;
+import org.eclipse.jface.text.ITextViewer;
+
+/**
+ * Delegates hover to the text hover implementation of cdt.
+ */
+public class DebugHoverProvider implements ITextHover, ITextHoverExtension, ITextHoverExtension2 {
+	@Override
+	public IInformationControlCreator getHoverControlCreator() {
+		return getDelegate(ITextHoverExtension.class).map(ITextHoverExtension::getHoverControlCreator).orElse(null);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Override
+	public String getHoverInfo(ITextViewer textViewer, IRegion hoverRegion) {
+		return getDelegate(ITextHover.class).map(delegate -> delegate.getHoverInfo(textViewer, hoverRegion))
+				.orElse(null);
+	}
+
+	@Override
+	public IRegion getHoverRegion(ITextViewer textViewer, int offset) {
+		return getDelegate(ITextHover.class).map(delegate -> delegate.getHoverRegion(textViewer, offset)).orElse(null);
+	}
+
+	@Override
+	public Object getHoverInfo2(ITextViewer textViewer, IRegion hoverRegion) {
+		return getDelegate(ITextHoverExtension2.class).map(delegate -> delegate.getHoverInfo2(textViewer, hoverRegion))
+				.orElse(null);
+	}
+
+	private <T> Optional<T> getDelegate(Class<T> clazz) {
+		return Optional.ofNullable(DebugUITools.getDebugContext())
+				.map(adaptable -> adaptable.getAdapter(ICEditorTextHover.class)).filter(Objects::nonNull)
+				.filter(clazz::isInstance).map(clazz::cast);
+	}
+
+}

--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -40,6 +40,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/cdt/releases/11.2/" />
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.cdt.platform.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository/" />


### PR DESCRIPTION
Adds a hover provider which delegates to the cdt debug hover mechanism.

Fixes issue #70.

Requires the following pull requests to be merged:
https://github.com/eclipse-cdt/cdt/pull/396
https://github.com/eclipse-platform/eclipse.platform.text/pull/200