### PR TITLE
Add lazy bundle activation

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.cdt.lsp.clangd
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.cdt.lsp.clangd;singleton:=true
 Bundle-Version: 1.0.0.qualifier


### PR DESCRIPTION
Otherwise the class
"org.eclipse.cdt.lsp.internal.clangd.CdtCLanguageServerProvider" can't be instantiated by "org.eclipse.cdt.lsp" in extension point.