### PR TITLE
[#77] Remove/replace old plugin path "org.eclipse.cdt.lsp.editor.ui"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Not supported (yet):
 - Call hierarchy
 - Include browser (Eclipse CDT speciality)
 
-The `org.eclipse.cdt.lsp.editor.ui` plugin provides an activation for the LSP based C/C++ Editor on project and workspace level. 
+The `org.eclipse.cdt.lsp` plugin provides an activation for the LSP based C/C++ Editor on project and workspace level. 
 The language server path and the arguments can be changed in the workspace preferences as well:
 
 ![image](images/preferences.png "preferences.png")

--- a/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
@@ -13,19 +13,22 @@
 <plugin>
    <extension
          point="org.eclipse.ui.preferencePages">
+      <!-- FIXME: AF: Exract clangd-specific preferences -->
+      <!-- FIXME: AF: Move commmon part to "org.eclipse.cdt.lsp[.editor]" -->
       <page
             category="org.eclipse.cdt.ui.preferences.CPluginPreferencePage"
             class="org.eclipse.cdt.lsp.internal.clangd.editor.preferences.LspEditorPreferencePage"
-            id="org.eclipse.cdt.lsp.editor.ui.preference.page"
+            id="org.eclipse.cdt.lsp.clangd.editor.preferences.general"
             name="Editor (LSP)">
       </page>
    </extension>
    <extension
          point="org.eclipse.ui.propertyPages">
+      <!-- FIXME: AF: Move me to "org.eclipse.cdt.lsp[.editor]" -->
       <page
             category="org.eclipse.cdt.ui.newui.Page_head_general"
             class="org.eclipse.cdt.lsp.internal.clangd.editor.properties.LspEditorPropertiesPage"
-            id="org.eclipse.cdt.lsp.editor.ui.properties.page"
+            id="org.eclipse.cdt.lsp.editor.properties.general"
             name="Editor (LSP)">
          <filter
                name="projectNature"
@@ -40,18 +43,20 @@
    </extension>
    <extension
          point="org.eclipse.core.expressions.propertyTesters">
+      <!-- FIXME: AF: Move me to "org.eclipse.cdt.lsp" -->
       <propertyTester
             class="org.eclipse.cdt.lsp.internal.clangd.editor.expressions.LspEditorPreferencesTester"
-            id="org.eclipse.cdt.lsp.editor.ui.lspEditorPreference"
-            namespace="org.eclipse.cdt.lsp.editor.ui"
-            properties="LspEditorPreference"
+            id="org.eclipse.cdt.lsp.expressions.lsp.prefer"
+            namespace="org.eclipse.cdt.lsp"
+            properties="prefer"
             type="java.lang.Object">
       </propertyTester>
+      <!-- FIXME: AF: Move me to "org.eclipse.cdt.lsp[.editor]" -->
       <propertyTester
             class="org.eclipse.cdt.lsp.internal.clangd.editor.expressions.LspEditorActiveTester"
-            id="org.eclipse.cdt.lsp.editor.ui.isLspCEditor"
-            namespace="org.eclipse.cdt.lsp.editor.ui"
-            properties="isLspCEditor"
+            id="org.eclipse.cdt.lsp.editor.active"
+            namespace="org.eclipse.cdt.lsp.editor"
+            properties="active"
             type="java.lang.Object">
       </propertyTester>
    </extension>
@@ -63,7 +68,7 @@
          <enabledWhen>
             <test
                   forcePluginActivation="true"
-                  property="org.eclipse.cdt.lsp.editor.ui.LspEditorPreference">
+                  property="org.eclipse.cdt.lsp.prefer">
             </test>
          </enabledWhen>
       </server>
@@ -71,15 +76,16 @@
 
   <extension
          point="org.eclipse.ui.commands">
+      <!-- FIXME: AF: Register "org.eclipse.cdt.lsp.clangd.editor.commands.category.extensions" -->
       <command
-            id="org.eclipse.cdt.lsp.editor.ui.toggle_source_and_header"
+            id="org.eclipse.cdt.lsp.clangd.editor.commands.command.switchSourceHeader"
             name="%Commands.ToggleSourceAndHeader.name">
       </command>
    </extension>
    <extension
          point="org.eclipse.ui.bindings">
       <key
-            commandId="org.eclipse.cdt.lsp.editor.ui.toggle_source_and_header"
+            commandId="org.eclipse.cdt.lsp.clangd.editor.commands.command.switchSourceHeader"
             contextId="org.eclipse.ui.genericeditor.genericEditorContext"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+TAB">
@@ -89,11 +95,11 @@
          point="org.eclipse.ui.handlers">
       <handler
             class="org.eclipse.cdt.lsp.internal.clangd.editor.handlers.ToggleSourceAndHeaderCommandHandler"
-            commandId="org.eclipse.cdt.lsp.editor.ui.toggle_source_and_header">
+            commandId="org.eclipse.cdt.lsp.clangd.editor.commands.command.switchSourceHeader">
          <activeWhen>
             	<with variable="activeEditor">
                 <test
-                      property="org.eclipse.cdt.lsp.editor.ui.isLspCEditor">
+                      property="org.eclipse.cdt.lsp.editor.active">
                 </test>
             	</with>
          </activeWhen>
@@ -105,7 +111,7 @@
             allPopups="false"
             locationURI="popup:org.eclipse.ui.popup.any?before=org.eclipse.lsp4e.openCallHierarchy">
          <command
-               commandId="org.eclipse.cdt.lsp.editor.ui.toggle_source_and_header"
+               commandId="org.eclipse.cdt.lsp.clangd.editor.commands.command.switchSourceHeader"
                label="%PopupMenu.ToggleSourceAndHeader.label"
                style="push">
             <visibleWhen

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/LspEditorUiPlugin.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/LspEditorUiPlugin.java
@@ -33,6 +33,7 @@ public class LspEditorUiPlugin extends AbstractUIPlugin {
 	private CProjectChangeMonitor cProjectChangeMonitor;
 
 	// The plug-in ID
+	//FIXME: AF: change this value together with preferences rework
 	public static final String PLUGIN_ID = "org.eclipse.cdt.lsp.editor.ui"; //$NON-NLS-1$
 
 	// The shared instance

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/expressions/LspEditorActiveTester.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/expressions/LspEditorActiveTester.java
@@ -26,7 +26,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
  * editor id.
  */
 public class LspEditorActiveTester extends PropertyTester {
-	public final static String IS_LSP_CEDITOR_PROPERTY = "isLspCEditor";
+	public final static String IS_LSP_CEDITOR_PROPERTY = "active";
 
 	@Override
 	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {


### PR DESCRIPTION
All except PLUGIN_ID itself are reworked
PLUGIN_ID rework will follow together with preference rework, see https://github.com/eclipse-cdt/cdt-lsp/issues/83

Required for https://github.com/eclipse-cdt/cdt-lsp/issues/77