### PR TITLE
Target Update: Update to CDT 11.1 and latest Orbit

### DIFF
--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -38,15 +38,14 @@
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/cdt/releases/10.7/" />
+			<repository location="https://download.eclipse.org/tools/cdt/releases/11.1/" />
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository/" />
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository/" />
 			<unit id="com.google.guava" version="0.0.0" />
 			<unit id="org.yaml.snakeyaml" version="0.0.0" />
-			<unit id="org.mockito" version="0.0.0"/>
-			<unit id="org.mockito.source" version="0.0.0"/>
+			<unit id="org.mockito.mockito-core" version="0.0.0"/>
 		</location>
 	</locations>
 </target>

--- a/tests/org.eclipse.cdt.lsp.clangd.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.cdt.lsp.clangd.tests/META-INF/MANIFEST.MF
@@ -12,6 +12,6 @@ Require-Bundle: junit-jupiter-api,
  net.bytebuddy.byte-buddy,
  net.bytebuddy.byte-buddy-agent,
  org.eclipse.cdt.lsp,
- org.mockito,
  org.objenesis,
- org.yaml.snakeyaml
+ org.yaml.snakeyaml,
+ org.mockito.mockito-core


### PR DESCRIPTION
I am trying to setup the project for the first time and reliased we need to update to the target to the latest plugins.

- Update to the latest CDT 11.1
- Update to the latest release eclipse orbit R20230302014618 and updated mockito plugin accordingly

https://download.eclipse.org/tools/orbit/downloads/
https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/
