### PR TITLE
[#87] Set clangd fallbackFlags on Windows

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/CdtCLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/CdtCLanguageServerProvider.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.cdt.lsp.internal.clangd;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 public class CdtCLanguageServerProvider extends DefaultCLanguageServerProvider {
 	//FIXME: AF: rework to core preferences
 	private static final IPreferenceStore preferenceStore = LspEditorUiPlugin.getDefault().getLsPreferences();
+	private final ClangdFallbackManager clangdFallbackManager = new ClangdFallbackManager();
 
 	@Override
 	protected List<String> createCommands() {
@@ -38,13 +40,18 @@ public class CdtCLanguageServerProvider extends DefaultCLanguageServerProvider {
 		return commandsFromStore;
 	}
 
+	@Override
+	public Object getInitializationOptions(URI rootUri) {
+		return clangdFallbackManager.getFallbackFlagsFromInitialUri();
+	}
+
 	private void setPreferenceStoreDefaults(List<String> commands) {
 		if (!commands.isEmpty()) {
 			//set values in preference store:
 			preferenceStore.setDefault(LspEditorPreferences.SERVER_PATH, commands.get(0));
-			String args = "";
+			String args = ""; //$NON-NLS-1$
 			for (int i = 1; i < commands.size(); i++) {
-				args = args + " " + commands.get(i);
+				args = args + " " + commands.get(i); //$NON-NLS-1$
 			}
 			preferenceStore.setDefault(LspEditorPreferences.SERVER_OPTIONS, args);
 		}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdFallbackManager.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdFallbackManager.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bachmann electronic GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.cdt.lsp.internal.clangd;
+
+import java.util.Optional;
+
+import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
+import org.eclipse.cdt.lsp.InitialFileManager;
+import org.eclipse.cdt.lsp.LspUtils;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.ServiceCaller;
+import org.eclipse.osgi.service.environment.Constants;
+
+/**
+ * Used to set the clangd fallbackFlags.
+ * This is needed for Windows OS to allow clangd to determine the system includes in case no compile_commands.json can be found.
+ * see also: https://clangd.llvm.org/extensions#compilation-commands
+ *
+ */
+public class ClangdFallbackManager {
+
+	class FallbackFlags {
+		// fallbackFlags is used as element name in the initialize jsonrpc call:
+		// "initializationOptions":{"fallbackFlags":[...
+		final String fallbackFlags[];
+
+		FallbackFlags(String[] systemIncludes) {
+			this.fallbackFlags = systemIncludes;
+			if (systemIncludes != null) {
+				for (int i = 0; i < systemIncludes.length; i++) {
+					this.fallbackFlags[i] = ISYSTEM.concat(systemIncludes[i]);
+				}
+			}
+		}
+	}
+
+	private static final String ISYSTEM = "-isystem"; //$NON-NLS-1$
+	private final ServiceCaller<ICBuildConfigurationManager> configManagerServiceCaller = new ServiceCaller<>(
+			getClass(), ICBuildConfigurationManager.class);
+	private final InitialFileManager initialFileManager = InitialFileManager.getInstance();
+	private final boolean isWindows = Constants.OS_WIN32.equals(Platform.getOS());
+
+	public FallbackFlags getFallbackFlagsFromInitialUri() {
+		if (isWindows) {
+			var configManager = configManagerServiceCaller.current();
+			try {
+				var initialFile = Optional.of(initialFileManager).map(m -> m.getInitialUri()).map(LspUtils::getFile)
+						.orElse(Optional.empty());
+				if (initialFile.isPresent() && configManager.isPresent()) {
+					var activeBuildConfig = initialFile.get().getProject().getActiveBuildConfig();
+					var cBuildConfig = configManager.get().getBuildConfiguration(activeBuildConfig);
+					if (cBuildConfig != null) {
+						var scannerInfo = cBuildConfig.getScannerInformation(initialFile.get());
+						if (scannerInfo != null) {
+							return new FallbackFlags(scannerInfo.getIncludePaths());
+						}
+					}
+				}
+			} catch (CoreException e) {
+				Platform.getLog(ClangdFallbackManager.class).error(e.getMessage(), e);
+			}
+		}
+		return null;
+	}
+}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/InitialFileManager.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/InitialFileManager.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bachmann electronic GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.cdt.lsp;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.QualifiedName;
+
+public class InitialFileManager {
+	private static InitialFileManager initialFileManager = null;
+	private static final QualifiedName INITIAL_URI = new QualifiedName(LspPlugin.PLUGIN_ID, "initialUri"); //$NON-NLS-1$
+	private final IWorkspaceRoot workspaceRoot;
+	private URI uri;
+
+	private InitialFileManager() {
+		workspaceRoot = LspPlugin.getDefault().getWorkspace().getRoot();
+	}
+
+	public static synchronized InitialFileManager getInstance() {
+		if (initialFileManager == null)
+			initialFileManager = new InitialFileManager();
+
+		return initialFileManager;
+	}
+
+	public synchronized void setInitialUri(URI uri) {
+		if (this.uri == null && LspUtils.getProject(uri).isPresent()) {
+			try {
+				workspaceRoot.setPersistentProperty(INITIAL_URI, uri.toString());
+				this.uri = uri;
+			} catch (CoreException e) {
+				Platform.getLog(InitialFileManager.class).error(e.getMessage(), e);
+			}
+		}
+	}
+
+	public Optional<URI> getInitialUri() {
+		if (this.uri == null) {
+			String initialUriString = null;
+			try {
+				initialUriString = workspaceRoot.getPersistentProperty(INITIAL_URI);
+				if (initialUriString != null) {
+					this.uri = new URI(initialUriString);
+				}
+			} catch (CoreException | URISyntaxException e) {
+				Platform.getLog(InitialFileManager.class).error(e.getMessage(), e);
+			}
+		}
+		return Optional.ofNullable(this.uri);
+	}
+}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
@@ -14,7 +14,10 @@ package org.eclipse.cdt.lsp;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
@@ -94,8 +97,7 @@ public class LspUtils {
 				if (uri.equals(editorUnputURI)) {
 					// should return false when an external header file with same URI is opened in a LSP editor
 					// and non LSP editor and tab switching from a non LSP editor to the tab with the file in the non LSP editor:
-					return LspPlugin.LSP_C_EDITOR_ID.equals(editor.getEditor(true).getEditorSite().getId())
-							&& isLspEditorActive();
+					return LspPlugin.LSP_C_EDITOR_ID.equals(editor.getId()) && isLspEditorActive();
 				}
 			}
 			// the file has not been opened yet -> goto definition/declaration case
@@ -149,6 +151,20 @@ public class LspUtils {
 			}
 		}
 		return false;
+	}
+
+	public static Optional<IProject> getProject(URI uri) {
+		return getFile(Optional.ofNullable(uri)).map(file -> file.getProject());
+	}
+
+	public static Optional<IFile> getFile(Optional<URI> uri) {
+		if (uri.isPresent()) {
+			IFile[] files = LspPlugin.getDefault().getWorkspace().getRoot().findFilesForLocationURI(uri.get());
+			if (files.length > 0) {
+				return Optional.ofNullable(files[0]);
+			}
+		}
+		return Optional.empty();
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/server/CLanguageServerStreamConnectionProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/server/CLanguageServerStreamConnectionProvider.java
@@ -12,19 +12,26 @@
 
 package org.eclipse.cdt.lsp.internal.server;
 
-import org.eclipse.cdt.lsp.LspPlugin;
-import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
-import org.eclipse.lsp4e.server.StreamConnectionProvider;
+import java.net.URI;
 
-public class CLanguageServerStreamConnectionProvider extends ProcessStreamConnectionProvider
-		implements StreamConnectionProvider {
+import org.eclipse.cdt.lsp.LspPlugin;
+import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
+import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
+
+public class CLanguageServerStreamConnectionProvider extends ProcessStreamConnectionProvider {
+	private final ICLanguageServerProvider cLanguageServerProvider;
 
 	public CLanguageServerStreamConnectionProvider() {
-		var cLanguageServerProvider = LspPlugin.getDefault().getCLanguageServerProvider();
+		this.cLanguageServerProvider = LspPlugin.getDefault().getCLanguageServerProvider();
 		setCommands(cLanguageServerProvider.getCommands());
 
 		// set the working directory for the Java process which runs the C/C++ language server:
-		setWorkingDirectory(System.getProperty("user.dir"));
+		setWorkingDirectory(System.getProperty("user.dir")); //$NON-NLS-1$
+	}
+
+	@Override
+	public Object getInitializationOptions(URI rootUri) {
+		return this.cLanguageServerProvider.getInitializationOptions(rootUri);
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/ICLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/ICLanguageServerProvider.java
@@ -12,6 +12,7 @@
 
 package org.eclipse.cdt.lsp.server;
 
+import java.net.URI;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
@@ -31,6 +32,16 @@ public interface ICLanguageServerProvider {
 	 * @param commands
 	 */
 	public void setCommands(List<String> commands);
+
+	/**
+	 * Optional initialization options for the language server during. Will be put in the initialize jsonrpc call.
+	 *
+	 * @param rootUri
+	 * @return
+	 */
+	public default Object getInitializationOptions(URI rootUri) {
+		return null;
+	}
 
 	/**
 	 * The enable expression is used to determine if the language server should be enabled.

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/enable/HasLanguageServerPropertyTester.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/enable/HasLanguageServerPropertyTester.java
@@ -12,24 +12,34 @@
 
 package org.eclipse.cdt.lsp.server.enable;
 
+import java.io.File;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.cdt.core.model.ICProject;
 import org.eclipse.cdt.core.model.ITranslationUnit;
+import org.eclipse.cdt.lsp.InitialFileManager;
 import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.cdt.lsp.LspUtils;
 import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
 import org.eclipse.core.expressions.PropertyTester;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
 
 public class HasLanguageServerPropertyTester extends PropertyTester {
 	private final ICLanguageServerProvider cLanguageServerProvider;
+	private final List<String> cContentTypes = new ArrayList<>();
+	private final InitialFileManager initialFileManager;
 
 	public HasLanguageServerPropertyTester() {
-		cLanguageServerProvider = LspPlugin.getDefault().getCLanguageServerProvider();
+		this.cLanguageServerProvider = LspPlugin.getDefault().getCLanguageServerProvider();
+		this.cContentTypes.add("org.eclipse.cdt.core.cSource"); //$NON-NLS-1$
+		this.cContentTypes.add("org.eclipse.cdt.core.cHeader"); //$NON-NLS-1$
+		this.cContentTypes.add("org.eclipse.cdt.core.cxxSource"); //$NON-NLS-1$
+		this.cContentTypes.add("org.eclipse.cdt.core.cxxHeader"); //$NON-NLS-1$
+		this.initialFileManager = InitialFileManager.getInstance();
 	}
 
 	@Override
@@ -38,9 +48,15 @@ public class HasLanguageServerPropertyTester extends PropertyTester {
 			if (receiver instanceof URI) {
 				// called from the language server enabler for LSP4E:
 				var uri = (URI) receiver;
+				if (!validContentType(uri))
+					return false;
 				// when getProject is empty, it's an external file: Check if the file is already opened, if not check the active editor:
-				return getProject(uri).map(cLanguageServerProvider::isEnabledFor)
+				var isEnabled = LspUtils.getProject(uri).map(cLanguageServerProvider::isEnabledFor)
 						.orElse(LspUtils.isFileOpenedInLspEditor(uri));
+				if (isEnabled) {
+					initialFileManager.setInitialUri(uri);
+				}
+				return isEnabled;
 			} else if (receiver instanceof ITranslationUnit) {
 				// called to enable the LS based CSymbolsContentProvider:
 				return Optional.of((ITranslationUnit) receiver).map(ITranslationUnit::getCProject)
@@ -54,12 +70,12 @@ public class HasLanguageServerPropertyTester extends PropertyTester {
 		return false;
 	}
 
-	private Optional<IProject> getProject(URI uri) {
-		IFile[] files = LspPlugin.getDefault().getWorkspace().getRoot().findFilesForLocationURI(uri);
-		if (files.length > 0) {
-			return Optional.ofNullable(files[0].getProject());
+	private boolean validContentType(URI uri) {
+		var contentType = Platform.getContentTypeManager().findContentTypeFor(new File(uri.getPath()).getName());
+		if (contentType != null) {
+			return cContentTypes.stream().anyMatch(type -> type.equals(contentType.getId()));
 		}
-		return Optional.empty();
+		return false;
 	}
 
 }


### PR DESCRIPTION
clangd has trouble on Windows machines to detect the system headers. Therefore we add the includes paths from the first project file opened by the LS client to the fallbackFlags.

see https://clangd.llvm.org/extensions#compilation-commands

LIMITATION: The include path detection by
ICBuildConfiguration.getScannerInformation works currently only for the clang compiler. g++/gcc doesn't work.

fixes #87