### PR TITLE
[#41] Delete codan markers

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jface.text,
  org.eclipse.debug.ui,
  org.eclipse.lsp4j,
- org.eclipse.lsp4j.jsonrpc
+ org.eclipse.lsp4j.jsonrpc,
+ org.eclipse.cdt.codan.core
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.cdt.lsp
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
prior to open a file with the LSP based C/C++ editor. When a C/C++ file has been opened prior by the old CDT C/C++ editor the codan markers are persistent and must be removed from the resource.

fixed #41