### PR TITLE
[#81] hide clangd property and preference pages

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
@@ -29,7 +29,8 @@ Require-Bundle: org.eclipse.cdt.lsp;bundle-version="0.0.0",
  org.eclipse.ui.editors;bundle-version="0.0.0",
  org.eclipse.ui.ide;bundle-version="0.0.0",
  org.eclipse.ui.workbench;bundle-version="0.0.0",
- org.eclipse.ui.workbench.texteditor;bundle-version="0.0.0"
+ org.eclipse.ui.workbench.texteditor;bundle-version="0.0.0",
+ org.eclipse.ui;bundle-version="0.0.0"
 Bundle-Activator: org.eclipse.cdt.lsp.internal.clangd.editor.ClangdPlugin
 Service-Component: OSGI-INF/org.eclipse.cdt.lsp.internal.clangd.ClangdConfigurationAccess.xml,
  OSGI-INF/org.eclipse.cdt.lsp.internal.clangd.ClangdFallbackManager.xml

--- a/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
@@ -58,6 +58,13 @@
             properties="active"
             type="java.lang.Object">
       </propertyTester>
+      <propertyTester
+            class="org.eclipse.cdt.lsp.internal.clangd.editor.expressions.ClangdLanguageServerProviderActive"
+            id="org.eclipse.cdt.lsp.clangd.provider.active"
+            namespace="org.eclipse.cdt.lsp.clangd.provider"
+            properties="active"
+            type="java.lang.Object">
+      </propertyTester>
    </extension>
    <extension
          point="org.eclipse.cdt.lsp.serverProvider">
@@ -112,6 +119,23 @@
             </visibleWhen>
          </command>
       </menuContribution>
+   </extension>
+   <extension
+         point="org.eclipse.ui.activities">
+      <activity
+            id="org.eclipse.cdt.lsp.clangd.ClangdLanguageProvider"
+            name="CDT Clangd Language Server Provider">
+         <enabledWhen>
+            <test
+                  forcePluginActivation="true"
+                  property="org.eclipse.cdt.lsp.clangd.provider.active">
+            </test></enabledWhen>
+      </activity>
+      <activityPatternBinding
+            activityId="org.eclipse.cdt.lsp.clangd.ClangdLanguageProvider"
+            isEqualityPattern="true"
+            pattern="org.eclipse.cdt.lsp.clangd/org.eclipse.cdt.lsp.clangd.editor">
+      </activityPatternBinding>
    </extension>
 
 </plugin>

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/expressions/ClangdLanguageServerProviderActive.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/expressions/ClangdLanguageServerProviderActive.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bachmann electronic GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.cdt.lsp.internal.clangd.editor.expressions;
+
+import org.eclipse.cdt.lsp.LspPlugin;
+import org.eclipse.cdt.lsp.internal.clangd.ClangdLanguageServerProvider;
+import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
+import org.eclipse.core.expressions.PropertyTester;
+
+public final class ClangdLanguageServerProviderActive extends PropertyTester {
+	private final ICLanguageServerProvider provider;
+
+	public ClangdLanguageServerProviderActive() {
+		this.provider = LspPlugin.getDefault().getCLanguageServerProvider();
+	}
+
+	@Override
+	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+		return provider instanceof ClangdLanguageServerProvider;
+	}
+
+}


### PR DESCRIPTION
hide pages when the ClangdLanguageServerProvider is not used.

see this [comment in #81](https://github.com/eclipse-cdt/cdt-lsp/issues/81#issuecomment-1589290227)