### PR TITLE
Fix broken fallback flags

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdFallbackManager.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdFallbackManager.java
@@ -68,9 +68,9 @@ public final class ClangdFallbackManager implements ClangdFallbackFlags {
 	public FallbackFlags getFallbackFlagsFromInitialUri(URI root) {
 		if (isWindows) {
 			return uri.find(root)//
-					.flatMap(new UriResource(workspace))//
-					.flatMap(this::flags)//
-					.orElse(null);
+					.flatMap(initUri -> new UriResource(workspace).apply(initUri))//
+					.map(this::flags)//
+					.orElse(Optional.empty()).orElse(null);
 		}
 		return null;
 	}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/UriResource.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/UriResource.java
@@ -30,16 +30,6 @@ public final class UriResource implements Function<URI, Optional<IResource>> {
 
 	@Override
 	public Optional<IResource> apply(URI uri) {
-		return forContainer(uri).or(() -> forFile(uri));
-	}
-
-	private Optional<IResource> forContainer(URI uri) {
-		return Arrays.stream(workspace.getRoot().findContainersForLocationURI(uri))//
-				.map(IResource.class::cast)//
-				.findFirst();
-	}
-
-	private Optional<IResource> forFile(URI uri) {
 		return Arrays.stream(workspace.getRoot().findFilesForLocationURI(uri))//
 				.map(IResource.class::cast)//
 				.findFirst();


### PR DESCRIPTION
The fallback flags determination was broken:
- CMakeBuildConfiguration.getScannerInformation(IResource) needs a File as input since the infos are stored in a map with a File as key. This will fail if IResource is a Folder.
- ClangdFallbackManager.flags(IResource): IResource must be the initialFile, not the initialProject, because the
getScannerInformation(IResource) needs a project file which can be found in the compile_commands.json in the project. Otherwise the compiler settings cannot be determined my the cmake bundle in CDT.