### PR TITLE
[#134] Fix broken fallback flags

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdFallbackManager.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdFallbackManager.java
@@ -20,7 +20,7 @@ import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
 import org.eclipse.cdt.core.parser.IScannerInfo;
 import org.eclipse.cdt.lsp.InitialUri;
-import org.eclipse.cdt.lsp.UriResource;
+import org.eclipse.cdt.lsp.ExistingResource;
 import org.eclipse.cdt.lsp.clangd.ClangdFallbackFlags;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
@@ -68,7 +68,7 @@ public final class ClangdFallbackManager implements ClangdFallbackFlags {
 	public FallbackFlags getFallbackFlagsFromInitialUri(URI root) {
 		if (isWindows) {
 			return uri.find(root)//
-					.flatMap(new UriResource(workspace))//
+					.flatMap(new ExistingResource(workspace))//
 					.flatMap(this::flags)//
 					.orElse(null);
 		}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ResolveProject.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ResolveProject.java
@@ -17,7 +17,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.eclipse.cdt.lsp.UriResource;
+import org.eclipse.cdt.lsp.ExistingResource;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
@@ -25,10 +25,10 @@ import org.eclipse.core.runtime.Adapters;
 
 public final class ResolveProject implements Function<Object, Optional<IProject>> {
 
-	private final UriResource resolve;
+	private final ExistingResource resolve;
 
 	public ResolveProject(IWorkspace workspace) {
-		this.resolve = new UriResource(workspace);
+		this.resolve = new ExistingResource(workspace);
 	}
 
 	@Override

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/ExistingResourceTest.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/ExistingResourceTest.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2023 ArSysOp and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Alexander Fedorov (ArSysOp) - initial API
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.eclipse.cdt.lsp.ExistingResource;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ExistingResourceTest {
+
+	@TempDir
+	private File TEMPORARY;
+	private IProject project;
+
+	private final ExistingResource resource = new ExistingResource(ResourcesPlugin.getWorkspace());
+
+	@BeforeEach
+	void create(TestInfo info) throws CoreException {
+		project = TestUtils.createCProject(info.getDisplayName());
+		project.open(new NullProgressMonitor());
+	}
+
+	@AfterEach
+	void delete() throws CoreException {
+		TestUtils.deleteProject(project);
+	}
+
+	@Test
+	public void testAbsentFile() {
+		IFile given = project.getFile("unknow");
+		Optional<IResource> found = resource.apply(given.getLocationURI());
+		assertTrue(found.isEmpty());
+	}
+
+	@Test
+	public void testExistingFile() {
+		IFile given = project.getFile(".project");
+		Optional<IResource> found = resource.apply(given.getLocationURI());
+		assertTrue(found.isPresent());
+		assertTrue(found.get() instanceof IFile);
+		assertEquals(given, found.get());
+	}
+
+	@Test
+	public void testAbsentFolder() {
+		IFolder given = project.getFolder("src");
+		Optional<IResource> found = resource.apply(given.getLocationURI());
+		assertTrue(found.isEmpty());
+	}
+
+	@Test
+	public void testExistingFolder() throws CoreException {
+		IFolder given = project.getFolder("src");
+		given.create(true, true, new NullProgressMonitor());
+		Optional<IResource> found = resource.apply(given.getLocationURI());
+		assertTrue(found.isPresent());
+		assertTrue(found.get() instanceof IFolder);
+		assertEquals(given, found.get());
+	}
+
+	@Test
+	public void testProject() {
+		IProject given = project;
+		Optional<IResource> found = resource.apply(given.getLocationURI());
+		assertTrue(found.isPresent());
+		assertEquals(given, found.get());
+	}
+
+	@Test
+	public void testExternal() throws IOException {
+		File external = new File(TEMPORARY, "ExternalHeader.hpp");
+		external.createNewFile();
+		Optional<IResource> found = resource.apply(external.toURI());
+		assertTrue(found.isEmpty());
+	}
+}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ExistingResource.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ExistingResource.java
@@ -20,11 +20,11 @@ import java.util.function.Function;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 
-public final class UriResource implements Function<URI, Optional<IResource>> {
+public final class ExistingResource implements Function<URI, Optional<IResource>> {
 
 	private final IWorkspace workspace;
 
-	public UriResource(IWorkspace workspace) {
+	public ExistingResource(IWorkspace workspace) {
 		this.workspace = Objects.requireNonNull(workspace);
 	}
 
@@ -36,12 +36,14 @@ public final class UriResource implements Function<URI, Optional<IResource>> {
 	private Optional<IResource> forContainer(URI uri) {
 		return Arrays.stream(workspace.getRoot().findContainersForLocationURI(uri))//
 				.map(IResource.class::cast)//
+				.filter(c -> c.exists())//
 				.findFirst();
 	}
 
 	private Optional<IResource> forFile(URI uri) {
 		return Arrays.stream(workspace.getRoot().findFilesForLocationURI(uri))//
 				.map(IResource.class::cast)//
+				.filter(c -> c.exists())//
 				.findFirst();
 	}
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/InitialFileManager.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/InitialFileManager.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 import org.eclipse.cdt.lsp.InitialUri;
 import org.eclipse.cdt.lsp.LspPlugin;
-import org.eclipse.cdt.lsp.UriResource;
+import org.eclipse.cdt.lsp.ExistingResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
@@ -38,7 +38,7 @@ public final class InitialFileManager implements InitialUri {
 
 	@Override
 	public synchronized void register(URI uri) {
-		if (this.uri == null && new UriResource(workspace).apply(uri).isPresent()) {
+		if (this.uri == null && new ExistingResource(workspace).apply(uri).isPresent()) {
 			try {
 				workspace.getRoot().setPersistentProperty(INITIAL_URI, uri.toString());
 				this.uri = uri;

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/enable/HasLanguageServerPropertyTester.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/enable/HasLanguageServerPropertyTester.java
@@ -23,7 +23,7 @@ import org.eclipse.cdt.core.model.ITranslationUnit;
 import org.eclipse.cdt.lsp.InitialUri;
 import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.cdt.lsp.LspUtils;
-import org.eclipse.cdt.lsp.UriResource;
+import org.eclipse.cdt.lsp.ExistingResource;
 import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
 import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IResource;
@@ -80,7 +80,7 @@ public class HasLanguageServerPropertyTester extends PropertyTester {
 
 	private boolean enabledFor(URI uri) {
 		boolean[] provider = new boolean[1];
-		workspace.call(w -> provider[0] = new UriResource(w).apply(uri)//
+		workspace.call(w -> provider[0] = new ExistingResource(w).apply(uri)//
 				.map(IResource::getProject)//
 				//FIXME: AF: consider changing signature here from IProject to Object
 				.map(cLanguageServerProvider::isEnabledFor)//


### PR DESCRIPTION
Rename `UriResource` to `ExistingResource` and add tests, since original implementation just always return what it was asked for, without considering its existance.