### PR TITLE
[#139] fix slow content provider

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -143,7 +143,7 @@
                     value="org.eclipse.cdt.core.model.ITranslationUnit">
               </instanceof>
               <instanceof
-                    value="org.eclipse.lsp4e.outline.SymbolsModel$DocumentSymbolWithFile">
+                    value="org.eclipse.lsp4e.outline.SymbolsModel$DocumentSymbolWithURI">
               </instanceof></or>
            <test
                  forcePluginActivation="true"
@@ -155,7 +155,7 @@
    	   <possibleChildren>
           <or>
              <instanceof
-                   value="org.eclipse.lsp4e.outline.SymbolsModel$DocumentSymbolWithFile">
+                   value="org.eclipse.lsp4e.outline.SymbolsModel$DocumentSymbolWithURI">
              </instanceof>
           </or>
 	   </possibleChildren>
@@ -170,7 +170,7 @@
 		 <enablement>
 			<or>
           <instanceof
-                value="org.eclipse.lsp4e.outline.SymbolsModel$DocumentSymbolWithFile">
+                value="org.eclipse.lsp4e.outline.SymbolsModel$DocumentSymbolWithURI">
           </instanceof>
 			</or>
          </enablement>			

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/enable/HasLanguageServerPropertyTester.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/enable/HasLanguageServerPropertyTester.java
@@ -20,17 +20,17 @@ import java.util.Optional;
 
 import org.eclipse.cdt.core.model.ICProject;
 import org.eclipse.cdt.core.model.ITranslationUnit;
+import org.eclipse.cdt.lsp.ExistingResource;
 import org.eclipse.cdt.lsp.InitialUri;
 import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.cdt.lsp.LspUtils;
-import org.eclipse.cdt.lsp.ExistingResource;
 import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
 import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.ServiceCaller;
-import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 
 public class HasLanguageServerPropertyTester extends PropertyTester {
 	private final ICLanguageServerProvider cLanguageServerProvider;
@@ -61,7 +61,7 @@ public class HasLanguageServerPropertyTester extends PropertyTester {
 				// called to enable the LS based CSymbolsContentProvider:
 				return Optional.of((ITranslationUnit) receiver).map(ITranslationUnit::getCProject)
 						.map(ICProject::getProject).map(cLanguageServerProvider::isEnabledFor).orElse(Boolean.FALSE);
-			} else if (receiver instanceof DocumentSymbolWithFile) {
+			} else if (receiver instanceof DocumentSymbolWithURI) {
 				// called to enable the LS based CSymbolsContentProvider:
 				return true;
 			}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/navigator/CSymbolsOpenActionProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/navigator/CSymbolsOpenActionProvider.java
@@ -22,7 +22,7 @@ import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IViewPart;
@@ -42,7 +42,7 @@ public class CSymbolsOpenActionProvider extends CommonActionProvider {
 
 	private class OpenCFileAction extends OpenFileAction {
 		private IWorkbenchPage page;
-		private DocumentSymbolWithFile fOpenElement;
+		private DocumentSymbolWithURI fOpenElement;
 
 		public OpenCFileAction(IWorkbenchPage page) {
 			super(page);
@@ -67,8 +67,8 @@ public class CSymbolsOpenActionProvider extends CommonActionProvider {
 			fOpenElement = null;
 			if (selection.size() == 1) {
 				Object element = selection.getFirstElement();
-				if (element instanceof DocumentSymbolWithFile) {
-					fOpenElement = (DocumentSymbolWithFile) element;
+				if (element instanceof DocumentSymbolWithURI) {
+					fOpenElement = (DocumentSymbolWithURI) element;
 				}
 			}
 			return fOpenElement != null || super.updateSelection(selection);
@@ -78,7 +78,7 @@ public class CSymbolsOpenActionProvider extends CommonActionProvider {
 			return page;
 		}
 
-		private void revealInEditor(IEditorPart part, DocumentSymbolWithFile element) {
+		private void revealInEditor(IEditorPart part, DocumentSymbolWithURI element) {
 			if (element == null) {
 				return;
 			}
@@ -157,8 +157,8 @@ public class CSymbolsOpenActionProvider extends CommonActionProvider {
 			return;
 		}
 		IFile file;
-		if (selection.getFirstElement() instanceof DocumentSymbolWithFile) {
-			file = LSPEclipseUtils.getFileHandle(((DocumentSymbolWithFile) selection.getFirstElement()).uri);
+		if (selection.getFirstElement() instanceof DocumentSymbolWithURI) {
+			file = LSPEclipseUtils.getFileHandle(((DocumentSymbolWithURI) selection.getFirstElement()).uri);
 			if (file == null) {
 				return;
 			}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/navigator/FileBufferListenerAdapter.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/navigator/FileBufferListenerAdapter.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bachmann electronic GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Gesa Hentschke (Bachmann electronic GmbH) - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.cdt.lsp.ui.navigator;
+
+import org.eclipse.core.filebuffers.IFileBuffer;
+import org.eclipse.core.filebuffers.IFileBufferListener;
+import org.eclipse.core.runtime.IPath;
+
+abstract class FileBufferListenerAdapter implements IFileBufferListener {
+
+	@Override
+	public void bufferCreated(IFileBuffer buffer) {
+	}
+
+	@Override
+	public void bufferDisposed(IFileBuffer buffer) {
+	}
+
+	@Override
+	public void bufferContentAboutToBeReplaced(IFileBuffer buffer) {
+	}
+
+	@Override
+	public void bufferContentReplaced(IFileBuffer buffer) {
+	}
+
+	@Override
+	public void stateChanging(IFileBuffer buffer) {
+	}
+
+	@Override
+	public void dirtyStateChanged(IFileBuffer buffer, boolean isDirty) {
+	}
+
+	@Override
+	public void stateValidationChanged(IFileBuffer buffer, boolean isStateValidated) {
+	}
+
+	@Override
+	public void underlyingFileMoved(IFileBuffer buffer, IPath path) {
+	}
+
+	@Override
+	public void underlyingFileDeleted(IFileBuffer buffer) {
+	}
+
+	@Override
+	public void stateChangeFailed(IFileBuffer buffer) {
+	}
+
+}

--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.23.0/" />
+			<repository location="https://download.eclipse.org/lsp4e/snapshots/" />
 			<unit id="org.eclipse.lsp4e" version="0.0.0" />
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
 		</location>


### PR DESCRIPTION
the symbols has not been cached and due to the disconnect of the file from buffer every call of refreshTreeContentFromLS triggers a new AST build on server side for the file. This can take a while for a large codebase. The solution is to cache the symbols for a file in the SymbolsContainer. The symbols will only be refreshed when the buffer is dirty.

Replaced the deprecated DocumentSymbolWithFile by DocumentSymbolWithURI

fixes #139