### PR TITLE
[#151] Use unique id for clangd property and preference page

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
@@ -24,7 +24,7 @@
       <page
             category="org.eclipse.cdt.ui.preferences.CPluginPreferencePage"
             class="org.eclipse.cdt.lsp.internal.clangd.editor.ClangdConfigurationPage"
-            id="org.eclipse.cdt.lsp.clangd.editor"
+            id="org.eclipse.cdt.lsp.clangd.editor.preference"
             name="Editor (LSP)">
       </page>
    </extension>
@@ -34,7 +34,7 @@
       <page
             category="org.eclipse.cdt.ui.newui.Page_head_general"
             class="org.eclipse.cdt.lsp.internal.clangd.editor.ClangdConfigurationPage"
-            id="org.eclipse.cdt.lsp.clangd.editor"
+            id="org.eclipse.cdt.lsp.clangd.editor.property"
             name="Editor (LSP)">
          <filter
                name="projectNature"
@@ -133,8 +133,8 @@
       </activity>
       <activityPatternBinding
             activityId="org.eclipse.cdt.lsp.clangd.ClangdLanguageProvider"
-            isEqualityPattern="true"
-            pattern="org.eclipse.cdt.lsp.clangd/org.eclipse.cdt.lsp.clangd.editor">
+            isEqualityPattern="false"
+            pattern="org.eclipse.cdt.lsp.clangd/org.eclipse.cdt.lsp.clangd.editor.*">
       </activityPatternBinding>
    </extension>
 

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/ClangdConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/ClangdConfigurationPage.java
@@ -54,7 +54,7 @@ import org.osgi.service.prefs.BackingStoreException;
 
 public final class ClangdConfigurationPage extends PropertyPage implements IWorkbenchPreferencePage {
 
-	private final String id = "org.eclipse.cdt.lsp.clangd.editor"; //$NON-NLS-1$
+	private final String id = "org.eclipse.cdt.lsp.clangd.editor.preference"; //$NON-NLS-1$
 
 	private ClangdConfiguration configuration;
 	private IWorkspace workspace;


### PR DESCRIPTION
This allows a vendor to change the visibility of the clangd preference and property page separately.

Fixes #151