### PR TITLE
[#150] Restart clangd when clangd settings changed

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/ClangdConfigurationArea.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/ClangdConfigurationArea.java
@@ -34,10 +34,12 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.events.TypedEvent;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 
@@ -65,13 +67,25 @@ public final class ClangdConfigurationArea {
 		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		composite.setLayout(GridLayoutFactory.fillDefaults().numColumns(columns).create());
 		this.prefer = createCheckbox(metadata.preferClangd(), composite);
-		this.path = createFileSelector(metadata.clangdPath(), composite, this::selectClangdExecutable);
-		this.tidy = createCheckbox(metadata.useTidy(), composite);
-		this.index = createCheckbox(metadata.useBackgroundIndex(), composite);
-		this.completion = createText(metadata.completionStyle(), composite, false);
-		this.pretty = createCheckbox(metadata.prettyPrint(), composite);
-		this.driver = createText(metadata.queryDriver(), composite, false);
-		this.additional = createText(metadata.additionalOptions(), composite, true);
+		Group group = createGroup(composite, LspEditorUiMessages.LspEditorPreferencePage_clangd_options_label);
+		this.path = createFileSelector(metadata.clangdPath(), group, this::selectClangdExecutable);
+		this.tidy = createCheckbox(metadata.useTidy(), group);
+		this.index = createCheckbox(metadata.useBackgroundIndex(), group);
+		this.completion = createText(metadata.completionStyle(), group, false);
+		this.pretty = createCheckbox(metadata.prettyPrint(), group);
+		this.driver = createText(metadata.queryDriver(), group, false);
+		this.additional = createText(metadata.additionalOptions(), group, true);
+	}
+
+	private Group createGroup(Composite parent, String label) {
+		Group group = new Group(parent, SWT.NONE);
+		group.setFont(parent.getFont());
+		group.setText(label);
+		GridLayout layout = new GridLayout();
+		layout.numColumns = 3;
+		group.setLayout(layout);
+		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		return group;
 	}
 
 	private Button createCheckbox(PreferenceMetadata<Boolean> meta, Composite composite) {
@@ -96,7 +110,7 @@ public final class ClangdConfigurationArea {
 		text.addKeyListener(KeyListener.keyReleasedAdapter(this::changed));
 		text.setLayoutData(GridDataFactory.fillDefaults().grab(true, false).span(columns - 2, 1).create());
 		Button button = new Button(composite, SWT.NONE);
-		button.setText("Browse...");
+		button.setText(LspEditorUiMessages.LspEditorPreferencePage_browse_button);
 		button.setLayoutData(new GridData());
 		button.addSelectionListener(SelectionListener.widgetSelectedAdapter(selector));
 		return text;
@@ -167,6 +181,15 @@ public final class ClangdConfigurationArea {
 		listeners.clear();
 		buttons.clear();
 		texts.clear();
+	}
+
+	public boolean optionsChanged(ClangdOptions options) {
+		return !options.clangdPath().equals(path.getText()) || options.useTidy() != tidy.getSelection()
+				|| options.useBackgroundIndex() != index.getSelection()
+				|| !options.completionStyle().equals(completion.getText())
+				|| options.prettyPrint() != pretty.getSelection() || !options.queryDriver().equals(driver.getText())
+				|| !options.additionalOptions().stream().collect(Collectors.joining(System.lineSeparator()))
+						.equals(additional.getText());
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/LspEditorUiMessages.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/LspEditorUiMessages.java
@@ -28,6 +28,13 @@ public class LspEditorUiMessages extends NLS {
 	public static String LspEditorPreferencePage_preferLspEditor_description;
 	public static String LspEditorPreferencePage_server_options;
 	public static String LspEditorPreferencePage_server_path;
+	public static String LspEditorPreferencePage_restart_dialog_title;
+	public static String LspEditorPreferencePage_restart_dialog_message;
+	public static String LspEditorPreferencePage_browse_button;
+	public static String LspEditorPreferencePage_restart_button;
+	public static String LspEditorPreferencePage_clangd_options_label;
+	public static String LspEditorPreferencePage_enable_project_specific;
+	public static String LspEditorPreferencePage_configure_ws_specific;
 
 	public static String LspEditorPropertiesPage_projectSpecificSettings;
 

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/LspEditorUiMessages.properties
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/LspEditorUiMessages.properties
@@ -16,8 +16,15 @@ LspEditorPreferencePage_preferLspEditor=Prefer C/C++ Editor (LSP)
 LspEditorPreferencePage_preferLspEditor_description=Prefer to use language server based C/C++ Editor instead of classic C/C++ Editor
 LspEditorPreferencePage_server_path=Path to the server executable:
 LspEditorPreferencePage_server_options=Command-line options for the server:
+LspEditorPreferencePage_restart_dialog_title=Clangd Restart Required
+LspEditorPreferencePage_restart_dialog_message=The clangd options have been modified.\nThese changes take effect after a clangd restart.\nDo you want to restart now?
+LspEditorPreferencePage_browse_button=Browse...
+LspEditorPreferencePage_restart_button=Restart
+LspEditorPreferencePage_clangd_options_label=clangd options
+LspEditorPreferencePage_enable_project_specific=Enable project-specific settings
+LspEditorPreferencePage_configure_ws_specific=Configure Workspace Settings...
 
 LspEditorPropertiesPage_projectSpecificSettings=Project specific editor settings
 
-CProjectChangeMonitor_yaml_scanner_error=Yaml scanner error
+CProjectChangeMonitor_yaml_scanner_error=Yaml Scanner Error
 CProjectChangeMonitor_yaml_scanner_error_message=Error while reading:


### PR DESCRIPTION
Ask the user to restart clangd when a clangd option has been modified in
the prefs or project properties. We stop the clangd language server.
When the user opens a new C/C++ file or an already opened C/C++ file in
the LSP based C/C++ editor gets into focus, a new LS will be started by
LSP4E.

Added a 'clangd options' group to the preference page. If any element in
this group will be modified, a info dialog pops up, when the 'Apply' or
'Apply and Close' button will be pressed. The dialog asks the user to
restart clangd.

fixes #150

![image](https://github.com/eclipse-cdt/cdt-lsp/assets/123444711/a2795eef-8da6-4aaf-b2e0-709fc0ef8458)

![image](https://github.com/eclipse-cdt/cdt-lsp/assets/123444711/d6599363-8ab9-4a1c-878d-774a7699c5aa)

