### PR TITLE
Fetch com.google.guava from lsp4j

### DIFF
--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -28,8 +28,12 @@
 			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
 		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/"/>
+			<unit id="com.google.guava" version="0.0.0"/>
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/mylyn/docs/releases/3.0.42/"/>
+			<repository location="https://download.eclipse.org/mylyn/docs/releases/3.0.45/"/>
 			<unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -40,10 +44,6 @@
 			<repository location="https://download.eclipse.org/tools/cdt/builds/11.3/cdt-11.3.0-m2a/"/>
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.cdt.platform.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/maven-osgi/milestone/S202307260706"/>
-			<unit id="com.google.guava" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09"/>


### PR DESCRIPTION
However, it works from lsp4j and not from
https://download.eclipse.org/tools/orbit/simrel/maven-osgi/milestone/S202307260706 or https://download.eclipse.org/tools/orbit/simrel/maven-osgi/milestone/latest Thats how LSP4E does it too.

fixes #180