### PR TITLE
do not copy array reference

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdFallbackManager.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdFallbackManager.java
@@ -19,8 +19,8 @@ import java.util.Optional;
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
 import org.eclipse.cdt.core.parser.IScannerInfo;
-import org.eclipse.cdt.lsp.InitialUri;
 import org.eclipse.cdt.lsp.ExistingResource;
+import org.eclipse.cdt.lsp.InitialUri;
 import org.eclipse.cdt.lsp.clangd.ClangdFallbackFlags;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
@@ -42,11 +42,11 @@ public final class ClangdFallbackManager implements ClangdFallbackFlags {
 	class FallbackFlags {
 		// fallbackFlags is used as element name in the initialize jsonrpc call:
 		// "initializationOptions":{"fallbackFlags":[...
-		final String fallbackFlags[];
+		String fallbackFlags[];
 
 		FallbackFlags(String[] systemIncludes) {
-			this.fallbackFlags = systemIncludes;
 			if (systemIncludes != null) {
+				fallbackFlags = new String[systemIncludes.length];
 				for (int i = 0; i < systemIncludes.length; i++) {
 					this.fallbackFlags[i] = ISYSTEM.concat(systemIncludes[i]);
 				}


### PR DESCRIPTION
because of: this.fallbackFlags = systemIncludes
the systemIncludes reference will be modified. This leads to the multiple prepending of '-isystem' to the include path ('-isystem-isystem-isystem<IncludePath>') when the LS gets started several times.