### PR TITLE
[#188] add OSGi service to enable clangd via project properties

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/org.eclipse.cdt.lsp.internal.clangd.ClangdConfigurationAccess.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/org.eclipse.cdt.lsp.internal.clangd.ClangdConfigurationAccess.xml
@@ -3,6 +3,7 @@
    <service>
       <provide interface="org.eclipse.cdt.lsp.clangd.ClangdConfiguration"/>
    </service>
+   <reference cardinality="0..1" field="enable" interface="org.eclipse.cdt.lsp.clangd.ClangdEnable" name="enable"/>
    <reference cardinality="1..1" field="metadata" interface="org.eclipse.cdt.lsp.clangd.ClangdMetadata" name="metadata"/>
    <reference cardinality="1..1" field="workspace" interface="org.eclipse.core.resources.IWorkspace" name="workspace"/>
    <implementation class="org.eclipse.cdt.lsp.internal.clangd.ClangdConfigurationAccess"/>

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdConfigurationVisibility.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdConfigurationVisibility.java
@@ -13,8 +13,9 @@
 package org.eclipse.cdt.lsp.clangd;
 
 /**
- * Provides access to the visibility of configuration elements in the UI taking into account the scope (project or workspace)
- *
+ * Provides access to the visibility of configuration elements in the UI taking into account the scope (project or workspace).
+ * Should be implemented as OSGi service when {@link ClangdEnable} service has been provided
+ * to hide the 'Prefer C/C++ Editor (LSP)' check-box.
  */
 public interface ClangdConfigurationVisibility {
 

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdEnable.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdEnable.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd;
+
+import org.eclipse.core.resources.IProject;
+
+/**
+ * Should be implemented by bundles as OSGi service to enable the Language
+ * Server and LSP based C/C++ Editor via project properties.
+ */
+public interface ClangdEnable {
+
+	/**
+	 * Checks whether clangd and the LSP based C/C++ Editor should be enabled for the given project.
+	 * The enable can be linked with certain project properties (e.g. project natures).
+	 * @param project
+	 * @return true when clangd and LSP based editor should be enabled for the given project
+	 */
+	public boolean isEnabledFor(IProject project);
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdConfigurationAccess.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdConfigurationAccess.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.cdt.lsp.clangd.ClangdConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdEnable;
 import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
 import org.eclipse.cdt.lsp.clangd.ClangdOptions;
 import org.eclipse.cdt.lsp.clangd.ClangdQualifier;
@@ -32,6 +33,7 @@ import org.eclipse.core.runtime.preferences.OsgiPreferenceMetadataStore;
 import org.eclipse.osgi.util.NLS;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 
 @Component
 public final class ClangdConfigurationAccess implements ClangdConfiguration {
@@ -42,6 +44,9 @@ public final class ClangdConfigurationAccess implements ClangdConfiguration {
 
 	@Reference
 	private IWorkspace workspace;
+
+	@Reference(cardinality = ReferenceCardinality.OPTIONAL)
+	private ClangdEnable enable;
 
 	public ClangdConfigurationAccess() {
 		this.qualifier = new ClangdQualifier().get();
@@ -54,7 +59,7 @@ public final class ClangdConfigurationAccess implements ClangdConfiguration {
 
 	@Override
 	public ClangdOptions defaults() {
-		return new ClangdPreferredOptions(qualifier, new IScopeContext[] { DefaultScope.INSTANCE }, metadata);
+		return new ClangdPreferredOptions(qualifier, new IScopeContext[] { DefaultScope.INSTANCE }, metadata, enable);
 	}
 
 	@Override
@@ -66,7 +71,7 @@ public final class ClangdConfigurationAccess implements ClangdConfiguration {
 		} else {
 			scopes = new IScopeContext[] { InstanceScope.INSTANCE, DefaultScope.INSTANCE };
 		}
-		return new ClangdPreferredOptions(qualifier, scopes, metadata);
+		return new ClangdPreferredOptions(qualifier, scopes, metadata, enable);
 	}
 
 	@Override

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdLanguageServerProvider.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.cdt.lsp.clangd.ClangdConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdEnable;
 import org.eclipse.cdt.lsp.clangd.ClangdFallbackFlags;
 import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
 import org.eclipse.core.resources.IProject;
@@ -49,7 +50,7 @@ public final class ClangdLanguageServerProvider implements ICLanguageServerProvi
 	@Override
 	public boolean isEnabledFor(IProject project) {
 		boolean[] enabled = new boolean[1];
-		configuration.call(c -> enabled[0] = c.options(project).preferClangd());
+		configuration.call(c -> enabled[0] = ((ClangdEnable) c.options(project)).isEnabledFor(project));
 		return enabled[0];
 	}
 

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdPreferredOptions.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/ClangdPreferredOptions.java
@@ -19,21 +19,25 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.cdt.lsp.clangd.ClangdEnable;
 import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
 import org.eclipse.cdt.lsp.clangd.ClangdOptions;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.PreferenceMetadata;
 
-final class ClangdPreferredOptions implements ClangdOptions {
+final class ClangdPreferredOptions implements ClangdOptions, ClangdEnable {
 
 	private final String qualifier;
 	private final IScopeContext[] scopes;
 	private final ClangdMetadata metadata;
+	private final ClangdEnable enable;
 
-	ClangdPreferredOptions(String qualifier, IScopeContext[] scopes, ClangdMetadata metadata) {
+	ClangdPreferredOptions(String qualifier, IScopeContext[] scopes, ClangdMetadata metadata, ClangdEnable enable) {
 		this.qualifier = Objects.requireNonNull(qualifier);
 		this.scopes = Objects.requireNonNull(scopes);
 		this.metadata = Objects.requireNonNull(metadata);
+		this.enable = enable;
 	}
 
 	@Override
@@ -95,6 +99,14 @@ final class ClangdPreferredOptions implements ClangdOptions {
 				.map(this::stringValue)//
 				.map(Boolean::valueOf)//
 				.orElseGet(meta::defaultValue);
+	}
+
+	@Override
+	public boolean isEnabledFor(IProject project) {
+		if (enable != null) {
+			return enable.isEnabledFor(project);
+		}
+		return booleanValue(metadata.preferClangd());
 	}
 
 }

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/META-INF/MANIFEST.MF
@@ -6,8 +6,11 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Version: 1.0.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.cdt.lsp.clangd
+ org.eclipse.cdt.lsp.clangd,
+ org.eclipse.core.resources
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.cdt.lsp.examples.preferences
 Bundle-ActivationPolicy: lazy
-Service-Component: OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.MyClangdOptionsDefaults.xml
+Service-Component: OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.MyClangdOptionsDefaults.xml,
+ OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.MyClangdEnable.xml,
+ OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.HidePreferClangd.xml

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.HidePreferClangd.xml
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.HidePreferClangd.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.cdt.lsp.examples.preferences.HidePreferClangd">
+   <implementation class="org.eclipse.cdt.lsp.examples.preferences.HidePreferClangd"/>
+   <property name="service.ranking" type="Integer" value="100"/>
+   <service>
+      <provide interface="org.eclipse.cdt.lsp.clangd.ClangdConfigurationVisibility"/>
+   </service>
+</scr:component>

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.MyClangdEnable.xml
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.MyClangdEnable.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.cdt.lsp.examples.preferences.MyClangdEnable">
+   <service>
+      <provide interface="org.eclipse.cdt.lsp.clangd.ClangdEnable"/>
+   </service>
+   <implementation class="org.eclipse.cdt.lsp.examples.preferences.MyClangdEnable"/>
+</scr:component>

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/build.properties
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/build.properties
@@ -1,5 +1,5 @@
-source.. = src/
-output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               OSGI-INF/org.eclipse.cdt.lsp.examples.preferences.MyClangdOptionsDefaults.xml
+               OSGI-INF/
+source.. = src/
+output.. = bin/

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/build.properties
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/build.properties
@@ -1,3 +1,16 @@
+###############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     See git history
+###############################################################################
+
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/src/org/eclipse/cdt/lsp/examples/preferences/HidePreferClangd.java
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/src/org/eclipse/cdt/lsp/examples/preferences/HidePreferClangd.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.examples.preferences;
+
+import org.eclipse.cdt.lsp.clangd.ClangdConfigurationVisibility;
+import org.osgi.service.component.annotations.Component;
+
+@Component(property = { "service.ranking:Integer=100" })
+public class HidePreferClangd implements ClangdConfigurationVisibility {
+
+	@Override
+	public boolean showPreferClangd(boolean isProjectScope) {
+		return false;
+	}
+
+	@Override
+	public boolean showClangdOptions(boolean isProjectScope) {
+		return true;
+	}
+
+}

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/src/org/eclipse/cdt/lsp/examples/preferences/MyClangdEnable.java
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/src/org/eclipse/cdt/lsp/examples/preferences/MyClangdEnable.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.examples.preferences;
+
+import org.eclipse.cdt.lsp.clangd.ClangdEnable;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.osgi.service.component.annotations.Component;
+
+@Component
+public class MyClangdEnable implements ClangdEnable {
+
+	@Override
+	public boolean isEnabledFor(IProject project) {
+		if (project != null) {
+			try {
+				return project.hasNature("org.eclipse.cdt.cmake.core.cmakeNature");
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
This allows vendors to enable clangd and the LSP based C/C++ Editor based on certain project properties (e.g. the project nature)

fixes #188