### PR TITLE
remove clangd options hiding

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdConfigurationVisibility.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdConfigurationVisibility.java
@@ -25,11 +25,4 @@ public interface ClangdConfigurationVisibility {
 	 */
 	boolean showPreferClangd(boolean isProjectScope);
 
-	/**
-	 * Changes the visibility of the 'clangd options' group.
-	 * @param isProjectScope
-	 * @return true when the clangd options group should be displayed.
-	 */
-	boolean showClangdOptions(boolean isProjectScope);
-
 }

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/ClangdConfigurationArea.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/ClangdConfigurationArea.java
@@ -101,7 +101,6 @@ public final class ClangdConfigurationArea {
 			this.prefer = null;
 		}
 		this.group = createGroup(composite, LspEditorUiMessages.LspEditorPreferencePage_clangd_options_label);
-		this.group.setVisible(visibility.showClangdOptions(isProjectScope));
 		this.path = createFileSelector(metadata.clangdPath(), group, this::selectClangdExecutable);
 		this.tidy = createCheckbox(metadata.useTidy(), group);
 		this.index = createCheckbox(metadata.useBackgroundIndex(), group);

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/DefaultClangdConfigurationVisibility.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/internal/clangd/editor/DefaultClangdConfigurationVisibility.java
@@ -23,9 +23,4 @@ public final class DefaultClangdConfigurationVisibility implements ClangdConfigu
 		return true;
 	}
 
-	@Override
-	public boolean showClangdOptions(boolean isProjectScope) {
-		return !isProjectScope; // TODO: return true when multiple LS per workspace are supported
-	}
-
 }


### PR DESCRIPTION
When clangd options are hidden in the project properties, the user has no idea which clangd optins are used, because even if they are hidden they are still in use when 'Enable project-specific settings' and 'Prefer C/C++ Editor (LSP)' is enabled.

fixes #189