### PR TITLE
update LSP4E dependency

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Bundle-Activator: org.eclipse.cdt.lsp.LspPlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.lsp4e;bundle-version="0.16.1",
+ org.eclipse.lsp4e;bundle-version="0.17.1",
  org.eclipse.tm4e.ui,
  org.eclipse.tm4e.languageconfiguration,
  org.eclipse.ui.genericeditor,


### PR DESCRIPTION
we should use at least 0.17.1 since there are several major improvements for our first release.