### PR TITLE
Save the zip file of the repository as part of the artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
   post {
     always {
       container('cdt') {
-        archiveArtifacts '**/*.log,**/target/repository/**'
+        archiveArtifacts '**/*.log,releng/org.eclipse.cdt.lsp.repository/target/**'
         junit '**/target/surefire-reports/*.xml'
       }
     }

--- a/releng/org.eclipse.cdt.lsp.repository/.project
+++ b/releng/org.eclipse.cdt.lsp.repository/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.cdt.lsp.repository</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/org.eclipse.cdt.lsp.repository/pom.xml
+++ b/releng/org.eclipse.cdt.lsp.repository/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2011, 2023 Contributors to the Eclipse Foundation
+
+   This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License 2.0
+   which accompanies this distribution, and is available at
+   https://www.eclipse.org/legal/epl-2.0/
+
+   SPDX-License-Identifier: EPL-2.0
+-->
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.cdt.lsp</groupId>
+    <artifactId>org.eclipse.cdt.lsp.root</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <version>1.0.0-SNAPSHOT</version>
+  <artifactId>org.eclipse.cdt.lsp.repository</artifactId>
+  <packaging>eclipse-repository</packaging>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+  </build>
+</project>


### PR DESCRIPTION
Includes removing version number from the zip file with the new pom.xml. This make writing the promotion scripts easier.

Part of https://github.com/eclipse-cdt/cdt-lsp/issues/197