### PR TITLE
Use final URLs for 2023-09 dependencies

### DIFF
--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="148">
+<target name="cdt" sequenceNumber="149">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/" />
 			<unit id="org.eclipse.license.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds/I20230903-1000/" />
+			<repository location="https://download.eclipse.org/eclipse/updates/4.29/R-4.29-202309031000/" />
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.jdt.annotation" version="0.0.0" />
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
@@ -43,7 +43,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<!-- We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace. -->
-			<repository location="https://download.eclipse.org/tools/cdt/builds/11.3/cdt-11.3.0-rc2/" />
+			<repository location="https://download.eclipse.org/tools/cdt/releases/11.3/cdt-11.3.0/" />
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
This synchronizes from main cdt.target