### PR TITLE
[#224] remove obsolete tm4e Cpp content type binding

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/LspUtilsTest.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/LspUtilsTest.java
@@ -27,11 +27,6 @@ class LspUtilsTest {
 	}
 
 	@Test
-	void testIsCContentType_CppContentTypeFromTM4E() {
-		assertTrue(LspUtils.isCContentType("lng.cpp"));
-	}
-
-	@Test
 	void testIsCContentType_CONTENT_TYPE_CSOURCE() {
 		assertTrue(LspUtils.isCContentType(CCorePlugin.CONTENT_TYPE_CSOURCE));
 	}

--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -33,16 +33,7 @@
          <contentTypeBinding
                contentTypeId="org.eclipse.cdt.core.cxxSource">
          </contentTypeBinding>
-         <contentTypeBinding
-               contentTypeId="lng.cpp"> <!-- // TODO: The content type definition from TM4E "lng.cpp" can be omitted here if either https://github.com/eclipse-cdt/cdt/pull/310 or 
-		// https://github.com/eclipse/tm4e/pull/500 has been merged. --> 
-         </contentTypeBinding>       
       </editor>
-      <editorContentTypeBinding
-            contentTypeId="lng.cpp"
-            editorId="org.eclipse.cdt.ui.editor.CEditor"> <!-- // TODO: The content type definition from TM4E "lng.cpp" can be omitted here if either https://github.com/eclipse-cdt/cdt/pull/310 or 
-		// https://github.com/eclipse/tm4e/pull/500 has been merged. --> 
-      </editorContentTypeBinding>
    </extension>
    <extension
          point="org.eclipse.lsp4e.languageServer">

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
@@ -47,10 +47,7 @@ public class LspUtils {
 	 * @return {@code true} if C/C++ content type
 	 */
 	public static boolean isCContentType(String id) {
-		// TODO: The content type definition from TM4E "lng.cpp" can be omitted if either https://github.com/eclipse-cdt/cdt/pull/310 or
-		// https://github.com/eclipse/tm4e/pull/500 has been merged.
-		return (id.startsWith("org.eclipse.cdt.core.c") && (id.endsWith("Source") || id.endsWith("Header"))) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-				|| "lng.cpp".equals(id); //$NON-NLS-1$
+		return (id.startsWith("org.eclipse.cdt.core.c") && (id.endsWith("Source") || id.endsWith("Header"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 
 	/**


### PR DESCRIPTION
Since this https://github.com/eclipse/tm4e/pull/500 lsp4e issue has been closed by this platform fix:
https://github.com/eclipse-platform/eclipse.platform/issues/151 we can now remove the contentTypeBinding to the lsp4e C++ content type definition.

fixes #224