### PR TITLE
Adapt target platform definition for using release versions

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/services/ast/AstNode.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/services/ast/AstNode.java
@@ -15,9 +15,9 @@ import java.util.Arrays;
 
 import org.eclipse.cdt.lsp.services.ClangdLanguageServer;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.jsonrpc.util.Preconditions;
-import org.eclipse.lsp4j.jsonrpc.util.ToStringBuilder;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.lsp4j.util.ToStringBuilder;
 
 /**
  * Return type for the <em>textDocument/ast</em> request.

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/services/ast/AstParams.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/services/ast/AstParams.java
@@ -14,9 +14,9 @@ package org.eclipse.cdt.lsp.services.ast;
 import org.eclipse.cdt.lsp.services.ClangdLanguageServer;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
-import org.eclipse.lsp4j.jsonrpc.util.Preconditions;
-import org.eclipse.lsp4j.jsonrpc.util.ToStringBuilder;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.lsp4j.util.ToStringBuilder;
 
 /**
  * Parameter object type for the <em>textDocument/ast</em> request.

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/services/symbolinfo/RangeAndUri.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/services/symbolinfo/RangeAndUri.java
@@ -13,9 +13,9 @@ package org.eclipse.cdt.lsp.services.symbolinfo;
 
 import org.eclipse.cdt.lsp.services.ClangdLanguageServer;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.jsonrpc.util.Preconditions;
-import org.eclipse.lsp4j.jsonrpc.util.ToStringBuilder;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.lsp4j.util.ToStringBuilder;
 
 /**
  * Data type used in {@link SymbolDetails} for the <em>textDocument/symbolInfo</em> request.

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/services/symbolinfo/SymbolDetails.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/services/symbolinfo/SymbolDetails.java
@@ -12,9 +12,9 @@
 package org.eclipse.cdt.lsp.services.symbolinfo;
 
 import org.eclipse.cdt.lsp.services.ClangdLanguageServer;
-import org.eclipse.lsp4j.jsonrpc.util.Preconditions;
-import org.eclipse.lsp4j.jsonrpc.util.ToStringBuilder;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.lsp4j.util.ToStringBuilder;
 
 /**
  * Return type for the <em>textDocument/symbolInfo</em> request.

--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -23,7 +23,7 @@
 			<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/snapshots/" />
+			<repository location="https://download.eclipse.org/lsp4e/releases/latest/" />
 			<unit id="org.eclipse.lsp4e" version="0.0.0" />
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
 		</location>
@@ -37,7 +37,7 @@
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tm4e/snapshots/" />
+			<repository location="https://download.eclipse.org/tm4e/releases/latest/" />
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0" />
 		</location>


### PR DESCRIPTION
I wondered why my last PR #256 didn't compile in the first place. It turns out, it's because the target definition file uses some repository locations pointing to snapshots instead of releases. I suppose that should be changed before releasing CDT LSP 1.1.0, right @ghentschke? This PR should do exactly that.

PR #256 didn't compile, because the target definition file uses snapshot versions for LSP4E. The latest LSP4E snapshot version uses LSP4J version `[0.22.0,0.23.0)`, but the latest LSP4E release version 0.24.8 uses LSP4J version `[0.21.0,0.22.0)`. These LSP4J versions are incompatible (due to some classes that were moved from one package to another). Since CDT LSP needs LSP4E 0.24.8, I think, we have to stick with LSP4J version 0.21.0.

I am not sure about the Docker repository location `https://download.eclipse.org/linuxtools/updates-docker-nightly`, depending on what it is used for, it may need to be replaced with a release versions repo, too.