### PR TITLE
Add API guarantee note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Fixed issues: <https://github.com/eclipse-cdt/cdt-lsp/milestone/1?closed=1>
 - Added basic spelling support
 - Added .clangd configuration file syntax checker
 - Added basic clangd LSP extension support for textDocument/ast and textDocument/symbolInfo
+- There is no API guarantee between 1.0.0 and 1.1.0. API stability will be added starting in a future release. See [#212](https://github.com/eclipse-cdt/cdt-lsp/issues/212)
 
 Fixed issues: <https://github.com/eclipse-cdt/cdt-lsp/milestone/2?closed=1>


### PR DESCRIPTION
In light of conversation in https://github.com/eclipse-cdt/cdt-lsp/pull/265#issuecomment-1957738075 lets make it explicit that there is no API guarantee yet.