### PR TITLE
Update to latest dependencies

### DIFF
--- a/.github/workflows/tycho-build.yaml
+++ b/.github/workflows/tycho-build.yaml
@@ -14,9 +14,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v.4.5
+        uses: stCarolas/setup-maven@v5
         with:
-          maven-version: 3.8.7          
+          maven-version: 3.9.6
       - name: Download clangd
         run: |
           curl -L https://github.com/clangd/clangd/releases/download/15.0.6/clangd-linux-15.0.6.zip > clangd.zip

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ check_code_cleanliness_workspace/
 .META-INF_MANIFEST.MF
 *.takari_issue_192
 *.log
+pom.tycho
 .tycho-consumer-pom.xml
 /eclipse/
 /*~

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>2.7.5</version>
+    <version>4.0.6</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,10 @@
  <packaging>pom</packaging>
 
  <properties>
-  <tycho.version>2.7.5</tycho.version>
-  <cbi-plugins.version>1.3.4</cbi-plugins.version>
+  <tycho.version>4.0.6</tycho.version>
+  <cbi-plugins.version>1.4.3</cbi-plugins.version>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  <tycho.scmUrl>scm:git:https://github.com/eclipse-cdt/cdt-lsp</tycho.scmUrl>
  </properties>
 
   <pluginRepositories>
@@ -52,6 +53,47 @@
             </dependencies>
             <product>org.eclipse.platform.ide</product>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-packaging-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <deriveHeaderFromProject>false</deriveHeaderFromProject>
+            <deriveHeaderFromSource>false</deriveHeaderFromSource>
+          <!-- Uncomment this to make jgit timestamps work (you may want to pull out jgit.dirtyWorkingTree as a variable)
+               This can't be done until bundles get version bumped because otherwise the version numbers go backwards 
+            <format>${qualifier.format}</format>
+            <timestampProvider>jgit</timestampProvider>
+            <jgit.ignore>
+              pom.xml
+              .polyglot.*
+            </jgit.ignore>
+            <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree> -->
+            <sourceReferences>
+              <generate>true</generate>
+            </sourceReferences>
+          </configuration>
+          <dependencies>
+            <!-- Uncomment this to make jgit timestamps work 
+            <dependency>
+              <groupId>org.eclipse.tycho</groupId>
+              <artifactId>tycho-buildtimestamp-jgit</artifactId>
+              <version>${tycho.version}</version>
+            </dependency> -->
+            <dependency>
+              <groupId>org.eclipse.tycho.extras</groupId>
+              <artifactId>tycho-sourceref-jgit</artifactId>
+              <version>${tycho.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <!-- disable default consumer pom. not needed here, and it shows a warning for each module -->
+              <id>default-update-consumer-pom</id>
+              <phase>none</phase>
+            </execution>
+          </executions>
         </plugin>
      </plugins>
    </pluginManagement>

--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -7,7 +7,7 @@
 			<unit id="org.eclipse.license.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.29/R-4.29-202309031000/" />
+			<repository location="https://download.eclipse.org/eclipse/updates/4.31-I-builds/" />
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.jdt.annotation" version="0.0.0" />
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
@@ -43,7 +43,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<!-- We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace. -->
-			<repository location="https://download.eclipse.org/tools/cdt/releases/11.3/cdt-11.3.0/" />
+			<repository location="https://download.eclipse.org/tools/cdt/releases/11.4/cdt-11.4.0/" />
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -195,11 +195,7 @@
 			</dependencies>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09"/>
-			<!-- failureaccess is needed because the Linuxtools depends on it but doesn't republish it - https://github.com/eclipse-linuxtools/org.eclipse.linuxtools/issues/232
-			This dep can't be added to maven section because of https://github.com/eclipse-pde/eclipse.pde/issues/675 -->
-			<unit id="com.google.guava.failureaccess" version="0.0.0" />
-
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-03"/>
 			<unit id="org.hamcrest.core" version="1.3.0.v20230809-1000" />
 			<unit id="org.hamcrest.library" version="1.3.0.v20230809-1000" />
 			<unit id="org.junit" version="4.13.2.v20230809-1000" />


### PR DESCRIPTION
With recent changes to Linuxtools we need to start building against 4.31 I-builds.

The alternative is to not use nightly for linuxtools.

Requires that
https://github.com/eclipse-linuxtools/org.eclipse.linuxtools/pull/324 be merged and a new build completes.

Fixes #269