### PR TITLE
Bring cdt-lsp Jenkins configuration up to date with CDT's one

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,16 @@ pipeline {
     disableConcurrentBuilds()
   }
   stages {
+    stage('initialize PGP') {
+      steps {
+        container('cdt') {
+          withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
+            sh 'gpg --batch --import "${KEYRING}"'
+            sh 'for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u); do echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust; done'
+          }
+        }
+      }
+    }
     stage('Install clangd') {
       steps {
         container('cdt') {
@@ -28,7 +38,7 @@ pipeline {
                   export PATH=$PWD/clangd_15.0.6/bin:$PATH
                   which clangd
                   clangd --version
-                  /usr/share/maven/bin/mvn \
+                  /jipp/tools/apache-maven/latest/bin/mvn \
                       clean verify -B -V -X -e \
                       -Dmaven.test.failure.ignore=true \
                       -P production \

--- a/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
@@ -8,10 +8,10 @@ spec:
     args: ["/bin/sh", "-c", "/home/vnc/.vnc/xstartup.sh && cat"]
     resources:
       requests:
-        memory: "2662Mi"
+        memory: "10000Mi"
         cpu: "1"
       limits:
-        memory: "2662Mi"
+        memory: "10000Mi"
         cpu: "1"
     volumeMounts:
     - name: settings-xml
@@ -22,6 +22,11 @@ spec:
       mountPath: /home/jenkins/.m2/repository
     - name: volume-known-hosts
       mountPath: /home/jenkins/.ssh
+    - name: "jenkins-home"
+      mountPath: "/home/jenkins"
+      readOnly: false
+    - name: tools
+      mountPath: /jipp/tools
   - name: jnlp
     resources:
       requests:
@@ -45,3 +50,8 @@ spec:
   - name: volume-known-hosts
     configMap:
       name: known-hosts
+  - name: "jenkins-home"
+    emptyDir: {}
+  - name: tools
+    persistentVolumeClaim:
+      claimName: tools-claim-jiro-cdt


### PR DESCRIPTION
The recent change in #271 started needing a newer version of Maven. CDT already had that change made in so I make the same change here.

With https://github.com/eclipse-cdt/.eclipsefdn/pull/7 we can push to origin directly, letting the branch be tested with Jenkins before being merged. So this change is running as https://ci.eclipse.org/cdt/job/cdt-lsp/job/jonah%252Ffix-jenkins-build2/ right now.