### PR TITLE
fix: add visibleWhen to find references menu entry

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
@@ -116,6 +116,15 @@
                commandId="org.eclipse.ui.genericeditor.findReferences"
                label="%PopupMenu.FindReferences.label"
                style="push">
+            <visibleWhen
+                  checkEnabled="false">
+               <with
+                     variable="activeEditorId">
+                  <equals
+                        value="org.eclipse.cdt.lsp.CEditor">
+                  </equals>
+               </with>
+            </visibleWhen>
          </command>
       </menuContribution>
    </extension>


### PR DESCRIPTION
otherwise to 'Find Refernces' entries were made in the generic editor context menu.