### PR TITLE
fix ambiguous getStartedWrappers method call

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
@@ -139,7 +139,7 @@ public class LspUtils {
 	}
 
 	public static Stream<LanguageServerWrapper> getLanguageServers() {
-		return LanguageServiceAccessor.getStartedWrappers(null, null, true).stream()
+		return LanguageServiceAccessor.getStartedWrappers(null, true).stream()
 				.filter(w -> "org.eclipse.cdt.lsp.server".equals(w.serverDefinition.id)); //$NON-NLS-1$
 	}
 


### PR DESCRIPTION
Due to this
https://github.com/eclipse/lsp4e/commit/83954d550df9b41fdf48652c001715a59678325e change in the LSP4E repo, the LanguageServiceAccessor.getStartedWrappers call has become ambiguous. Removal of the project argument fixed it.