### PR TITLE
[#300] Add link to Generic Text Editors preference page

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.java
@@ -27,6 +27,8 @@ public class LspUiMessages extends NLS {
 
 	public static String LspEditorConfigurationPage_spelling_link;
 	public static String LspEditorConfigurationPage_spelling_link_tooltip;
+	public static String LspEditorConfigurationPage_content_assist_link;
+	public static String LspEditorConfigurationPage_content_assist_link_tooltip;
 
 	public static String LspEditorConfigurationPage_enable_project_specific;
 	public static String LspEditorConfigurationPage_configure_ws_specific;

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.properties
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.properties
@@ -15,6 +15,8 @@ NavigatorView_ErrorOnLoad = Loading the symbols encountered an error; see the Er
 
 LspEditorConfigurationPage_spelling_link=Spelling preferences are set via <a href="org.eclipse.ui.editors.preferencePages.Spelling">Text Editors Spelling</a>.
 LspEditorConfigurationPage_spelling_link_tooltip=Show the shared text editor spelling preferences
+LspEditorConfigurationPage_content_assist_link=Content Assist preferences are set via <a href="org.eclipse.ui.genericeditor.GenericTextEditor">Generic Text Editors</a>.
+LspEditorConfigurationPage_content_assist_link_tooltip=Show the generic text editors content assist preferences
 
 LspEditorConfigurationPage_enable_project_specific=Enable project-specific settings
 LspEditorConfigurationPage_configure_ws_specific=Configure Workspace Settings...

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/EditorConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/EditorConfigurationPage.java
@@ -167,7 +167,10 @@ public class EditorConfigurationPage extends PropertyPage implements IWorkbenchP
 		composite.setLayout(GridLayoutFactory.fillDefaults().create());
 		composite.setFont(parent.getFont());
 		if (!isProjectScope) {
-			createSpellingPreferencesLink(composite);
+			createLink(composite, LspUiMessages.LspEditorConfigurationPage_spelling_link,
+					LspUiMessages.LspEditorConfigurationPage_spelling_link_tooltip);
+			createLink(composite, LspUiMessages.LspEditorConfigurationPage_content_assist_link,
+					LspUiMessages.LspEditorConfigurationPage_content_assist_link_tooltip);
 			Label line = new Label(composite, SWT.SEPARATOR | SWT.HORIZONTAL);
 			line.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false, 2, 1));
 		}
@@ -175,12 +178,12 @@ public class EditorConfigurationPage extends PropertyPage implements IWorkbenchP
 		return composite;
 	}
 
-	private Control createSpellingPreferencesLink(Composite parent) {
+	private Control createLink(Composite parent, String text, String tooltipText) {
 		Link link = new Link(parent, SWT.NONE);
-		link.setText(LspUiMessages.LspEditorConfigurationPage_spelling_link);
+		link.setText(text);
 		link.addListener(SWT.Selection,
 				event -> PreferencesUtil.createPreferenceDialogOn(getShell(), event.text, null, null));
-		link.setToolTipText(LspUiMessages.LspEditorConfigurationPage_spelling_link_tooltip);
+		link.setToolTipText(tooltipText);
 		link.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false));
 		return link;
 	}


### PR DESCRIPTION
to let the user change the content assist settings for the lsp based C/C++ editor.

fixes #300