### PR TITLE
Fix #301 Also adapt the editor's icon depending on open file type

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -33,6 +33,12 @@
          <contentTypeBinding
                contentTypeId="org.eclipse.cdt.core.cxxSource">
          </contentTypeBinding>
+         <contentTypeBinding
+               contentTypeId="org.eclipse.cdt.core.cHeader">
+         </contentTypeBinding>
+         <contentTypeBinding
+               contentTypeId="org.eclipse.cdt.core.cxxHeader">
+         </contentTypeBinding>
       </editor>
    </extension>
    <extension
@@ -326,6 +332,25 @@
             </test>
          </enabledWhen>
       </reconciler>
+   </extension>
+   <extension
+         point="org.eclipse.ui.genericeditor.icons">
+      <icon
+            contentType="org.eclipse.cdt.core.cSource"
+            icon="icons/c.png">
+      </icon>
+      <icon
+            contentType="org.eclipse.cdt.core.cxxSource"
+            icon="icons/cpp.png">
+      </icon>
+      <icon
+            contentType="org.eclipse.cdt.core.cHeader"
+            icon="icons/h.png">
+      </icon>
+      <icon
+            contentType="org.eclipse.cdt.core.cxxHeader"
+            icon="icons/h.png">
+      </icon>
    </extension>  
 </plugin>
 


### PR DESCRIPTION
I also adapted the icon shown for a file opened in the CDT LSP editor, depending on whether it is a header file or a source file.