### PR TITLE
Update docker image to Java 21 by default

### DIFF
--- a/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
   - name: cdt
-    image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install@sha256:efa01be7dc63af2f239fff3ea929d2d79b07084983e9ab859eb480fcc17b5ba2
+    image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install@sha256:87cf4b58119836c1a784a049b3eaafe79ab1acd4c88455cd2cd41e5e31f0b900
     tty: true
     args: ["/bin/sh", "-c", "/home/vnc/.vnc/xstartup.sh && cat"]
     resources:


### PR DESCRIPTION
This synchronizes cdt-lsp to https://github.com/eclipse-cdt/cdt/pull/767 and makes the JIPP behave the same as GitHub actions that was changed in https://github.com/eclipse-cdt/cdt-lsp/pull/304