### PR TITLE
Update direct-from-maven dependencies to latest available minor versions

### DIFF
--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="150">
+<target name="cdt" sequenceNumber="151">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/" />
@@ -13,6 +13,9 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.test.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.unittest.ui" version="0.0.0" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/mylyn/updates/release/latest/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/egit/updates" />
@@ -54,14 +57,14 @@
 				<dependency>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
-					<version>2.0.7</version>
+					<version>2.0.13</version>
 					<type>jar</type>
 				</dependency>
-				<!-- slf4j-api requires 1 impl, providing a dummy one... -->
+				<!-- slf4j-api requires 1 impl, provide the one that is generally used in the final product, such as standalone debugger -->
 				<dependency>
 					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-nop</artifactId>
-					<version>2.0.7</version>
+					<artifactId>slf4j-simple</artifactId>
+					<version>2.0.13</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -78,19 +81,19 @@
 				<dependency>
 					<groupId>org.apache.commons</groupId>
 					<artifactId>commons-compress</artifactId>
-					<version>1.23.0</version>
+					<version>1.26.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
-					<version>2.13.0</version>
+					<version>2.16.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.assertj</groupId>
 					<artifactId>assertj-core</artifactId>
-					<version>3.24.2</version>
+					<version>3.25.3</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -102,43 +105,43 @@
 				<dependency>
 					<groupId>org.junit.jupiter</groupId>
 					<artifactId>junit-jupiter-api</artifactId>
-					<version>5.9.3</version>
+					<version>5.10.2</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.junit.jupiter</groupId>
 					<artifactId>junit-jupiter-engine</artifactId>
-					<version>5.9.3</version>
+					<version>5.10.2</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.mockito</groupId>
 					<artifactId>mockito-core</artifactId>
-					<version>5.4.0</version>
+					<version>5.12.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.yaml</groupId>
 					<artifactId>snakeyaml</artifactId>
-					<version>2.0</version>
+					<version>2.2</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>net.java.dev.jna</groupId>
 					<artifactId>jna-platform</artifactId>
-					<version>5.13.0</version>
+					<version>5.14.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>net.java.dev.jna</groupId>
 					<artifactId>jna</artifactId>
-					<version>5.13.0</version>
+					<version>5.14.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
-					<version>32.1.1-jre</version>
+					<version>33.2.0-jre</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -154,31 +157,31 @@
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm-commons</artifactId>
-					<version>9.5</version>
+					<version>9.7</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm-util</artifactId>
-					<version>9.5</version>
+					<version>9.7</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm</artifactId>
-					<version>9.5</version>
+					<version>9.7</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm-tree</artifactId>
-					<version>9.5</version>
+					<version>9.7</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm-analysis</artifactId>
-					<version>9.5</version>
+					<version>9.7</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -195,7 +198,7 @@
 			</dependencies>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-03"/>
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-06"/>
 			<unit id="org.hamcrest.core" version="1.3.0.v20230809-1000" />
 			<unit id="org.hamcrest.library" version="1.3.0.v20230809-1000" />
 			<unit id="org.junit" version="4.13.2.v20230809-1000" />


### PR DESCRIPTION
Use orbit-aggregation/2024-06.

There is this new report:

https://github.com/eclipse-orbit/orbit-simrel/blob/main/report/maven-osgi/cdt-lsp/REPORT.md

This commit is effectively just a copy-and-paste (other than the aggregation update) of this:

https://raw.githubusercontent.com/eclipse-orbit/orbit-simrel/main/report/maven-osgi/cdt-lsp/updated.target