### PR TITLE
[#320] prevent possible NPE in isFileOpenedInLspEditor

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
@@ -94,7 +94,7 @@ public class LspUtils {
 					continue;
 				}
 				if (editorInput.equals(editorInputFromEditor)) {
-					return LspPlugin.LSP_C_EDITOR_ID.equals(editor.getEditor(true).getEditorSite().getId());
+					return LspPlugin.LSP_C_EDITOR_ID.equals(editor.getId());
 				}
 			}
 			// the file has not been opened yet:


### PR DESCRIPTION
getEditor can return null.

may be a fix for #320