### PR TITLE
[#327] fix blocking jobs

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/navigator/SymbolsManager.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/navigator/SymbolsManager.java
@@ -224,7 +224,7 @@ public class SymbolsManager implements IDeferredWorkbenchAdapter {
 		return EMPTY;
 	}
 
-	private synchronized void refreshTreeContentFromLS(CompileUnit compileUnit) {
+	private void refreshTreeContentFromLS(CompileUnit compileUnit) {
 		if (compileUnit == null || !compileUnit.isDirty) {
 			return;
 		}


### PR DESCRIPTION
...by removing synchronized from refreshTreeContentFromLS. The method will be called from different jobs started by the
DeferredTreeContentManager. The completable future returned by symbols.thenAcceptAsync cannot join, when the refreshTreeContentFromLS is synchronized.

fixes #327