### PR TITLE
[#328] make refreshTreeContentFromLS reentrant

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/navigator/SymbolsManager.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/navigator/SymbolsManager.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.cdt.core.model.ITranslationUnit;
 import org.eclipse.cdt.lsp.util.LspUtils;
@@ -52,6 +53,7 @@ import org.eclipse.ui.progress.IElementCollector;
 
 public class SymbolsManager implements IDeferredWorkbenchAdapter {
 	protected static final Object[] EMPTY = new Object[0];
+	private final ReentrantLock lock = new ReentrantLock();
 
 	class CompileUnit {
 		public final IFile file;
@@ -228,8 +230,8 @@ public class SymbolsManager implements IDeferredWorkbenchAdapter {
 		if (compileUnit == null || !compileUnit.isDirty) {
 			return;
 		}
+		lock.lock();
 		boolean temporaryLoadedDocument = false;
-
 		try {
 			IDocument document = LSPEclipseUtils.getExistingDocument(compileUnit.file);
 			if (document == null) {
@@ -275,6 +277,7 @@ public class SymbolsManager implements IDeferredWorkbenchAdapter {
 					Platform.getLog(getClass()).error(e.getMessage(), e);
 				}
 			}
+			lock.unlock();
 		}
 	}
 


### PR DESCRIPTION
- because the same SymbolsManager instance can be called from several jobs (threads) started by the DeferredTreeContentManager.

fixes a technical depth from PR #328