### PR TITLE
Remove debug log messages from maven

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                   which clangd
                   clangd --version
                   /jipp/tools/apache-maven/latest/bin/mvn \
-                      clean verify -B -V -X -e \
+                      clean verify -B -V -e \
                       -Dmaven.test.failure.ignore=true \
                       -Dgpg.passphrase="${KEYRING_PASSPHRASE}"  \
                       -P production \


### PR DESCRIPTION
These can be reenabled if diagnosing a problem, but shouldn't be there all the time as they slow down
the build and make the build output huge