### PR TITLE
[#342] use default editor to open external file

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -35,7 +35,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.lsp4j.jsonrpc;bundle-version="0.22.0",
  org.eclipse.cdt.codan.core,
  org.eclipse.cdt.debug.ui,
- org.eclipse.ui.workbench.texteditor
+ org.eclipse.ui.workbench.texteditor,
+ org.eclipse.core.filesystem
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.cdt.lsp
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -35,8 +35,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.lsp4j.jsonrpc;bundle-version="0.22.0",
  org.eclipse.cdt.codan.core,
  org.eclipse.cdt.debug.ui,
- org.eclipse.ui.workbench.texteditor,
- org.eclipse.core.filesystem
+ org.eclipse.ui.workbench.texteditor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.cdt.lsp
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CEditorAssociationOverride.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CEditorAssociationOverride.java
@@ -49,7 +49,7 @@ public class CEditorAssociationOverride implements IEditorAssociationOverride {
 		if (isNoCElement(contentType)) {
 			return editorDescriptors;
 		}
-		if (isEnabledFor(editorInput)) {
+		if (isEnabledFor(editorInput, contentType)) {
 			return editorFilter(LspPlugin.C_EDITOR_ID, editorDescriptors); // remove CDT C-Editor
 		}
 		return editorFilter(LspPlugin.LSP_C_EDITOR_ID, editorDescriptors); // remove LSP based C-Editor
@@ -82,7 +82,7 @@ public class CEditorAssociationOverride implements IEditorAssociationOverride {
 		return editorDescriptor;
 	}
 
-	private boolean isEnabledFor(IEditorInput editorInput) {
+	private boolean isEnabledFor(IEditorInput editorInput, IContentType contentType) {
 		if (cLanguageServerProvider == null)
 			return false;
 		IResource resource = editorInput.getAdapter(IResource.class);
@@ -94,7 +94,7 @@ public class CEditorAssociationOverride implements IEditorAssociationOverride {
 			return enabled;
 		}
 		// When resource == null it's an external file: Check if the file is already opened, if not check the active editor:
-		return LspUtils.isFileOpenedInLspEditor(editorInput);
+		return LspUtils.isFileOpenedInLspEditor(editorInput, contentType);
 	}
 
 	private void deleteCodanMarkers(IResource resource) {
@@ -141,7 +141,7 @@ public class CEditorAssociationOverride implements IEditorAssociationOverride {
 		if (isNoCElement(contentType))
 			return null;
 
-		if (isEnabledFor(editorInput)) {
+		if (isEnabledFor(editorInput, contentType)) {
 			return getEditorDescriptorById(editorInput.getName(), LspPlugin.LSP_C_EDITOR_ID, contentType); // return LSP based C/C++ Editor
 		}
 		// TODO: return null; when either https://github.com/eclipse-cdt/cdt/pull/310 or

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
@@ -24,6 +24,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.ServiceCaller;
+import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.ui.IEditorInput;
@@ -79,7 +80,7 @@ public class LspUtils {
 		return false;
 	}
 
-	public static boolean isFileOpenedInLspEditor(IEditorInput editorInput) {
+	public static boolean isFileOpenedInLspEditor(IEditorInput editorInput, IContentType contentType) {
 		if (editorInput == null) {
 			return false;
 		}
@@ -100,7 +101,9 @@ public class LspUtils {
 			// the file has not been opened yet:
 			return isLspEditorActive();
 		}
-		return false;
+		// check defaults:
+		var desc = PlatformUI.getWorkbench().getEditorRegistry().getDefaultEditor(editorInput.getName(), contentType);
+		return desc != null ? LspPlugin.LSP_C_EDITOR_ID.equals(desc.getId()) : false;
 	}
 
 	public static List<IEditorReference> getEditors() {


### PR DESCRIPTION
...when no other editor is opened to inherit editor type from

fixes #342