### PR TITLE
[#355] Disable 'Save Actions' property page when no C/C++ project

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -288,6 +288,7 @@
 	        id="org.eclipse.cdt.lsp.editor.SaveActionsPreferencePage">
 	      <keywordReference id="org.eclipse.cdt.ui.saveactions"/>
 	      <keywordReference id="org.eclipse.cdt.ui.common"/>
+	      <keywordReference id="org.eclipse.cdt.ui.ceditor"/>
       </page>      
    </extension>
    <extension
@@ -314,6 +315,11 @@
             name="%SaveActionsPreferencePage.name">
           <keywordReference id="org.eclipse.cdt.ui.saveactions"/>
 	      <keywordReference id="org.eclipse.cdt.ui.common"/>
+	      <keywordReference id="org.eclipse.cdt.ui.ceditor"/>
+       <filter
+             name="projectNature"
+             value="org.eclipse.cdt.core.cnature">
+       </filter>
        <enabledWhen>
           <adapt
                 type="org.eclipse.core.resources.IProject">


### PR DESCRIPTION
- currently the page is also in other project types visible
- adds the 'format' as well as other c editor keywords to the save actions page to improve lookup of preference/properties settings.

fixes #355