### PR TITLE
[#362] increase timeout for fetching format regions from LS

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/EditorPreferenceInitializer.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/EditorPreferenceInitializer.java
@@ -18,12 +18,18 @@ import org.eclipse.core.runtime.ServiceCaller;
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.PreferenceMetadata;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.lsp4e.LanguageServerPlugin;
 
 public final class EditorPreferenceInitializer extends AbstractPreferenceInitializer {
 
 	@Override
 	public void initializeDefaultPreferences() {
 		ServiceCaller.callOnce(getClass(), Configuration.class, this::initializeDefaults);
+
+		IPreferenceStore store = LanguageServerPlugin.getDefault().getPreferenceStore();
+		// increase timeout from 5 to 30 seconds. Fetching formatting regions from the language server for large files (>20k lines of code) can take more than 5 sec.:
+		store.setValue("org.eclipse.cdt.lsp.server.timeout.willSaveWaitUntil", 30); //$NON-NLS-1$
 	}
 
 	private void initializeDefaults(Configuration configuration) {

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/FormatOnSave.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/FormatOnSave.java
@@ -15,15 +15,23 @@ package org.eclipse.cdt.lsp.internal.editor;
 import org.eclipse.cdt.lsp.config.Configuration;
 import org.eclipse.cdt.lsp.editor.EditorOptions;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.format.IFormatRegionsProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 @Component(property = { "serverDefinitionId:String=org.eclipse.cdt.lsp.server" })
 public class FormatOnSave implements IFormatRegionsProvider {
+
+	public FormatOnSave() {
+		IPreferenceStore store = LanguageServerPlugin.getDefault().getPreferenceStore();
+		// increase timeout from 5 to 30 seconds. Fetching formatting regions from the language server for large files (>20k lines of code) can take more than 5 sec.:
+		store.setValue("org.eclipse.cdt.lsp.server.timeout.willSaveWaitUntil", 30); //$NON-NLS-1$
+	}
 
 	@Reference
 	private Configuration configuration;

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/FormatOnSave.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/FormatOnSave.java
@@ -15,23 +15,15 @@ package org.eclipse.cdt.lsp.internal.editor;
 import org.eclipse.cdt.lsp.config.Configuration;
 import org.eclipse.cdt.lsp.editor.EditorOptions;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.format.IFormatRegionsProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 @Component(property = { "serverDefinitionId:String=org.eclipse.cdt.lsp.server" })
 public class FormatOnSave implements IFormatRegionsProvider {
-
-	public FormatOnSave() {
-		IPreferenceStore store = LanguageServerPlugin.getDefault().getPreferenceStore();
-		// increase timeout from 5 to 30 seconds. Fetching formatting regions from the language server for large files (>20k lines of code) can take more than 5 sec.:
-		store.setValue("org.eclipse.cdt.lsp.server.timeout.willSaveWaitUntil", 30); //$NON-NLS-1$
-	}
 
 	@Reference
 	private Configuration configuration;


### PR DESCRIPTION
increase timeout from 5 to 30 seconds. Fetching formatting regions from the language server for large files (>20k lines of code) can take more than 5 sec.

fixes #362