### PR TITLE
fix LS restart after exception

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
@@ -85,7 +85,7 @@ public final class ClangdConfigurationPage extends EditorConfigurationPage {
 	}
 
 	private boolean isLsActive() {
-		return LspUtils.getLanguageServers(false).findFirst().filter(w -> w.startupFailed() || w.isActive())
+		return LspUtils.getLanguageServers(false).stream().findFirst().filter(w -> w.startupFailed() || w.isActive())
 				.isPresent();
 	}
 

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
@@ -64,7 +64,7 @@ public final class ClangdConfigurationPage extends EditorConfigurationPage {
 	}
 
 	private void restartClangd() {
-		LspUtils.getLanguageServers().forEach(w -> w.restart());
+		LspUtils.getLanguageServers(false).forEach(w -> w.restart());
 	}
 
 	/**
@@ -85,7 +85,8 @@ public final class ClangdConfigurationPage extends EditorConfigurationPage {
 	}
 
 	private boolean isLsActive() {
-		return LspUtils.getLanguageServers().findAny().isPresent();
+		return LspUtils.getLanguageServers(false).findFirst().filter(w -> w.startupFailed() || w.isActive())
+				.isPresent();
 	}
 
 	@Override

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
@@ -141,8 +141,21 @@ public class LspUtils {
 		return found.stream().findFirst();
 	}
 
+	/**
+	 * Get active language servers
+	 * @return Stream of LanguageServerWrapper
+	 */
 	public static Stream<LanguageServerWrapper> getLanguageServers() {
-		return LanguageServiceAccessor.getStartedWrappers(null, true).stream()
+		return getLanguageServers(true);
+	}
+
+	/**
+	 * Get language servers
+	 * @param onlyActiveLS
+	 * @return Stream of LanguageServerWrapper
+	 */
+	public static Stream<LanguageServerWrapper> getLanguageServers(boolean onlyActiveLS) {
+		return LanguageServiceAccessor.getStartedWrappers(null, onlyActiveLS).stream()
 				.filter(w -> "org.eclipse.cdt.lsp.server".equals(w.serverDefinition.id)); //$NON-NLS-1$
 	}
 

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.eclipse.cdt.lsp.plugin.LspPlugin;
 import org.eclipse.core.resources.IFile;
@@ -143,20 +142,20 @@ public class LspUtils {
 
 	/**
 	 * Get active language servers
-	 * @return Stream of LanguageServerWrapper
+	 * @return List of LanguageServerWrapper
 	 */
-	public static Stream<LanguageServerWrapper> getLanguageServers() {
+	public static List<LanguageServerWrapper> getLanguageServers() {
 		return getLanguageServers(true);
 	}
 
 	/**
 	 * Get language servers
 	 * @param onlyActiveLS
-	 * @return Stream of LanguageServerWrapper
+	 * @return List of LanguageServerWrapper
 	 */
-	public static Stream<LanguageServerWrapper> getLanguageServers(boolean onlyActiveLS) {
+	public static List<LanguageServerWrapper> getLanguageServers(boolean onlyActiveLS) {
 		return LanguageServiceAccessor.getStartedWrappers(null, onlyActiveLS).stream()
-				.filter(w -> "org.eclipse.cdt.lsp.server".equals(w.serverDefinition.id)); //$NON-NLS-1$
+				.filter(w -> "org.eclipse.cdt.lsp.server".equals(w.serverDefinition.id)).toList(); //$NON-NLS-1$
 	}
 
 }


### PR DESCRIPTION
due to this [LSP4E change 1044 ](https://github.com/eclipse/lsp4e/pull/1044)in LSP4E the restart of a LS, after an exception occurred during the start of the LS, is not possible anymore. This will be fixed.