### PR TITLE
switch OR statements

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
@@ -85,7 +85,7 @@ public final class ClangdConfigurationPage extends EditorConfigurationPage {
 	}
 
 	private boolean isLsActive() {
-		return LspUtils.getLanguageServers(false).stream().findFirst().filter(w -> w.startupFailed() || w.isActive())
+		return LspUtils.getLanguageServers(false).stream().findFirst().filter(w -> w.isActive() || w.startupFailed())
 				.isPresent();
 	}
 


### PR DESCRIPTION
to prevent java.lang.NoSuchMethodError: 'boolean
org.eclipse.lsp4e.LanguageServerWrapper.startupFailed()' when vendors has yet updated LSP4E. This is only a small workaround because the exception is still thrown when the LS config contains errors and the startup fails.