### PR TITLE
[#381] support all line breaks in clangd options list

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdPreferredOptions.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdPreferredOptions.java
@@ -72,7 +72,7 @@ final class ClangdPreferredOptions implements ClangdOptions {
 		if (options.isBlank()) {
 			return new ArrayList<>();
 		}
-		return Arrays.asList(options.split(System.lineSeparator()));
+		return Arrays.asList(options.split("\\R")); //$NON-NLS-1$
 	}
 
 	private String stringValue(PreferenceMetadata<?> meta) {


### PR DESCRIPTION
This change supports `\n` as well as `\r\n` independent of the OS.

fixes 381