### PR TITLE
log errors only

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/format/ClangFormatFileMonitor.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/format/ClangFormatFileMonitor.java
@@ -138,6 +138,7 @@ public class ClangFormatFileMonitor {
 		var list = new ArrayList<String>(2);
 		list.add(clangdPath);
 		list.add("--check=" + emptyFile.getLocation().toOSString()); //$NON-NLS-1$
+		list.add("--log=error"); //$NON-NLS-1$
 		return list;
 	}
 


### PR DESCRIPTION
this improves the validation check of .clang-format files since only errors are printed to clangd stderr stream.