### PR TITLE
[#369] add missing command category

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/l10n/bundle.properties
@@ -25,6 +25,8 @@ SPDX-License-Identifier: EPL-2.0\n\
 
 Commands.ToggleSourceAndHeader.name=Toggle Source/Header
 PopupMenu.ToggleSourceAndHeader.label=Toggle Source/Header
+Commands.Category.name=C/C++ Editor (LSP)
+Commands.Category.name.description=Commands used by the clangd based C/C++ editor
 PopupMenu.FindReferences.label=Find References
 ClangdConfigurationPage.name=clangd
 ClangFormatConfigurationPage.name=Formatter

--- a/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
@@ -92,9 +92,15 @@
          point="org.eclipse.ui.commands">
       <!-- FIXME: AF: Register "org.eclipse.cdt.lsp.clangd.editor.commands.category.extensions" -->
       <command
+            categoryId="org.eclipse.cdt.lsp.clangd.command.category"
             id="org.eclipse.cdt.lsp.clangd.editor.commands.command.switchSourceHeader"
             name="%Commands.ToggleSourceAndHeader.name">
       </command>
+      <category
+            description="%Commands.Category.name.description"
+            id="org.eclipse.cdt.lsp.clangd.command.category"
+            name="%Commands.Category.name">
+      </category>
    </extension>
    <extension
          point="org.eclipse.ui.bindings">


### PR DESCRIPTION
when no category is set, the key is not shown in the preference page. (filtered by default)

fixes #369