### PR TITLE
[#418] add Content Assist preference page to editor

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
@@ -34,6 +34,8 @@ Service-Component: OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangForm
  OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdCommandLineValidator.xml,
  OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdConfigurationAccess.xml,
  OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdConfigurationFileManager.xml,
+ OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistConfigurationAccess.xml,
+ OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistMetadataDefaults.xml,
  OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdFallbackManager.xml,
  OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdMetadataDefaults.xml,
  OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.DefaultClangdCompilationDatabaseSettings.xml

--- a/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/l10n/bundle.properties
@@ -30,3 +30,4 @@ Commands.Category.name.description=Commands used by the clangd based C/C++ edito
 PopupMenu.FindReferences.label=Find References
 ClangdConfigurationPage.name=clangd
 ClangFormatConfigurationPage.name=Formatter
+ContentAssistPreferencePage.name=Content Assist

--- a/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdConfigurationAccess.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdConfigurationAccess.xml
@@ -3,6 +3,7 @@
    <service>
       <provide interface="org.eclipse.cdt.lsp.clangd.ClangdConfiguration"/>
    </service>
+   <reference cardinality="1..1" field="contentAssistConfiguration" interface="org.eclipse.cdt.lsp.clangd.ClangdContentAssistConfiguration" name="contentAssistConfiguration"/>
    <reference cardinality="1..1" field="metadata" interface="org.eclipse.cdt.lsp.clangd.ClangdMetadata" name="metadata"/>
    <reference cardinality="1..1" field="workspace" interface="org.eclipse.core.resources.IWorkspace" name="workspace"/>
    <implementation class="org.eclipse.cdt.lsp.clangd.internal.config.ClangdConfigurationAccess"/>

--- a/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistConfigurationAccess.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistConfigurationAccess.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistConfigurationAccess">
+   <service>
+      <provide interface="org.eclipse.cdt.lsp.clangd.ClangdContentAssistConfiguration"/>
+   </service>
+   <reference cardinality="1..1" field="metadata" interface="org.eclipse.cdt.lsp.clangd.ClangdContentAssistMetadata" name="metadata"/>
+   <reference cardinality="1..1" field="workspace" interface="org.eclipse.core.resources.IWorkspace" name="workspace"/>
+   <implementation class="org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistConfigurationAccess"/>
+</scr:component>

--- a/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistMetadataDefaults.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistMetadataDefaults.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistMetadataDefaults">
+   <property name="service.ranking" type="Integer" value="0"/>
+   <service>
+      <provide interface="org.eclipse.cdt.lsp.clangd.ClangdContentAssistMetadata"/>
+   </service>
+   <implementation class="org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistMetadataDefaults"/>
+</scr:component>

--- a/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
@@ -38,6 +38,12 @@
             class="org.eclipse.cdt.lsp.clangd.internal.ui.ContentAssistConfigurationPage"
             id="org.eclipse.cdt.lsp.clangd.editor.contentAssistPreferencePage"
             name="%ContentAssistPreferencePage.name">
+         <keywordReference
+               id="org.eclipse.cdt.ui.contentassist">
+         </keywordReference>
+         <keywordReference
+               id="org.eclipse.cdt.ui.common">
+         </keywordReference>
       </page>
    </extension>
    <extension

--- a/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp.clangd/plugin.xml
@@ -16,6 +16,9 @@
       <initializer
             class="org.eclipse.cdt.lsp.clangd.internal.config.ClangdPreferenceInitializer">
       </initializer>
+      <initializer
+            class="org.eclipse.cdt.lsp.clangd.internal.config.ClangdContentAssistPreferenceInitializer">
+      </initializer>
    </extension>
    <extension
          point="org.eclipse.ui.preferencePages">
@@ -29,6 +32,12 @@
          <keywordReference
                id="org.eclipse.cdt.ui.ceditor">
          </keywordReference>
+      </page>
+      <page
+            category="org.eclipse.cdt.lsp.editor.preferencePage"
+            class="org.eclipse.cdt.lsp.clangd.internal.ui.ContentAssistConfigurationPage"
+            id="org.eclipse.cdt.lsp.clangd.editor.contentAssistPreferencePage"
+            name="%ContentAssistPreferencePage.name">
       </page>
    </extension>
    <extension

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdContentAssistConfiguration.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdContentAssistConfiguration.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd;
+
+import org.eclipse.cdt.lsp.config.Configuration;
+
+/**
+ * @since 3.0
+ */
+public interface ClangdContentAssistConfiguration extends Configuration {
+
+	@Override
+	ClangdContentAssistOptions defaults();
+
+	@Override
+	ClangdContentAssistOptions options(Object context);
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdContentAssistMetadata.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdContentAssistMetadata.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd;
+
+import org.eclipse.cdt.lsp.clangd.internal.ui.LspEditorUiMessages;
+import org.eclipse.cdt.lsp.config.ConfigurationMetadata;
+import org.eclipse.cdt.lsp.editor.EditorOptions;
+import org.eclipse.core.runtime.preferences.PreferenceMetadata;
+
+/**
+ * @since 3.0
+ */
+public interface ClangdContentAssistMetadata extends ConfigurationMetadata {
+
+	/**
+	 * Returns the metadata for the "Fill function arguments and show guessed arguments" option.
+	 *
+	 * @see EditorOptions#fillFunctionArguments()
+	 *
+	 * @since 3.0
+	 */
+	PreferenceMetadata<Boolean> fillFunctionArguments = new PreferenceMetadata<>(Boolean.class, //
+			"fill_function_arguments", //$NON-NLS-1$
+			true, //
+			LspEditorUiMessages.ContentAssistConfigurationPage_fill_function_arguments,
+			LspEditorUiMessages.ContentAssistConfigurationPage_fill_function_arguments_description);
+
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdContentAssistOptions.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdContentAssistOptions.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd;
+
+/**
+ * clangd content assist options
+ *
+ * @since 3.0
+ */
+public interface ClangdContentAssistOptions {
+
+	/**
+	 * When disabled, completions contain only parentheses for function calls. When enabled, completions also contain placeholders for function parameters
+	 * @return true if completions shall also contain placeholders for function parameters
+	 */
+	default boolean fillFunctionArguments() {
+		return true;
+	}
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdContentAssistQualifier.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdContentAssistQualifier.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd;
+
+import java.util.function.Supplier;
+
+/**
+ * @since 3.0
+ */
+public final class ClangdContentAssistQualifier implements Supplier<String> {
+
+	@Override
+	public String get() {
+		return "org.eclipse.cdt.lsp.clangd.content.assist"; //$NON-NLS-1$
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdConfigurationAccess.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdConfigurationAccess.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.cdt.lsp.clangd.ClangdConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistOptions;
 import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
 import org.eclipse.cdt.lsp.clangd.ClangdOptions;
 import org.eclipse.cdt.lsp.clangd.ClangdQualifier;
@@ -35,6 +37,9 @@ import org.osgi.service.component.annotations.Reference;
 
 @Component
 public final class ClangdConfigurationAccess extends ConfigurationAccess implements ClangdConfiguration {
+
+	@Reference
+	private ClangdContentAssistConfiguration contentAssistConfiguration;
 
 	@Reference
 	private ClangdMetadata metadata;
@@ -102,6 +107,9 @@ public final class ClangdConfigurationAccess extends ConfigurationAccess impleme
 		if (!options.queryDriver().isBlank()) {
 			list.add(NLS.bind("--query-driver={0}", options.queryDriver())); //$NON-NLS-1$
 		}
+		ClangdContentAssistOptions contentAssistOptions = contentAssistConfiguration.options(context);
+		list.add(NLS.bind("--function-arg-placeholders={0}", //$NON-NLS-1$
+				String.valueOf(contentAssistOptions.fillFunctionArguments())));
 
 		list.addAll(options.additionalOptions());
 		return list;

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdContentAssistConfigurationAccess.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdContentAssistConfigurationAccess.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd.internal.config;
+
+import java.util.Optional;
+
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistMetadata;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistOptions;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistQualifier;
+import org.eclipse.cdt.lsp.config.ConfigurationAccess;
+import org.eclipse.cdt.lsp.config.ConfigurationMetadata;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IPreferenceMetadataStore;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.OsgiPreferenceMetadataStore;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public final class ClangdContentAssistConfigurationAccess extends ConfigurationAccess
+		implements ClangdContentAssistConfiguration {
+
+	@Reference
+	private ClangdContentAssistMetadata metadata;
+
+	@Reference
+	private IWorkspace workspace;
+
+	public ClangdContentAssistConfigurationAccess() {
+		super(new ClangdContentAssistQualifier().get());
+	}
+
+	@Override
+	public IPreferenceMetadataStore storage(Object context) {
+		return new OsgiPreferenceMetadataStore(//
+				preferences(//
+						projectScope(workspace, context)//
+								.map(IScopeContext.class::cast)//
+								.orElse(InstanceScope.INSTANCE)));
+	}
+
+	@Override
+	public ConfigurationMetadata metadata() {
+		return metadata;
+	}
+
+	@Override
+	public String qualifier() {
+		return qualifier;
+	}
+
+	@Override
+	public ClangdContentAssistOptions defaults() {
+		return new ClangdContentAssistPreferredOptions(metadata, qualifier,
+				new IScopeContext[] { DefaultScope.INSTANCE });
+	}
+
+	@Override
+	public ClangdContentAssistOptions options(Object context) {
+		Optional<ProjectScope> project = projectScope(workspace, context);
+		IScopeContext[] scopes;
+		if (project.isPresent()) {
+			scopes = new IScopeContext[] { project.get(), InstanceScope.INSTANCE, DefaultScope.INSTANCE };
+		} else {
+			scopes = new IScopeContext[] { InstanceScope.INSTANCE, DefaultScope.INSTANCE };
+		}
+		return new ClangdContentAssistPreferredOptions(metadata, qualifier, scopes);
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdContentAssistMetadataDefaults.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdContentAssistMetadataDefaults.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistMetadata;
+import org.eclipse.cdt.lsp.config.ConfigurationMetadataBase;
+import org.eclipse.core.runtime.preferences.PreferenceMetadata;
+import org.osgi.service.component.annotations.Component;
+
+@Component(property = { "service.ranking:Integer=0" })
+public final class ClangdContentAssistMetadataDefaults extends ConfigurationMetadataBase
+		implements ClangdContentAssistMetadata {
+
+	@Override
+	protected List<PreferenceMetadata<?>> definePreferences() {
+		List<PreferenceMetadata<?>> defined = new ArrayList<>();
+		defined.add(fillFunctionArguments);
+		return defined;
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdContentAssistPreferenceInitializer.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdContentAssistPreferenceInitializer.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd.internal.config;
+
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistConfiguration;
+import org.eclipse.cdt.lsp.config.ConfigurationPreferencesDefaults;
+import org.eclipse.core.runtime.ServiceCaller;
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+
+public final class ClangdContentAssistPreferenceInitializer extends AbstractPreferenceInitializer {
+
+	@Override
+	public void initializeDefaultPreferences() {
+		ServiceCaller.callOnce(getClass(), ClangdContentAssistConfiguration.class,
+				new ConfigurationPreferencesDefaults<>());
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdContentAssistPreferredOptions.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdContentAssistPreferredOptions.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd.internal.config;
+
+import org.eclipse.cdt.lsp.PreferredOptions;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistMetadata;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistOptions;
+import org.eclipse.cdt.lsp.config.ConfigurationMetadata;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+
+public final class ClangdContentAssistPreferredOptions extends PreferredOptions implements ClangdContentAssistOptions {
+
+	public ClangdContentAssistPreferredOptions(ConfigurationMetadata metadata, String qualifier,
+			IScopeContext[] scopes) {
+		super(metadata, qualifier, scopes);
+	}
+
+	@Override
+	public boolean fillFunctionArguments() {
+		return booleanValue(ClangdContentAssistMetadata.fillFunctionArguments);
+	}
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
@@ -58,15 +58,12 @@ public final class ClangdConfigurationPage extends ConfigurationPage<ClangdConfi
 		var configSettingsChanged = configurationSettingsChanged();
 		var projectOptionsDifferFromWorkspace = projectOptionsDifferFromWorkspace();
 		var done = super.performOk();
-		if (done && isLsActive() && (((!projectScope().isPresent() || useProjectSettings()) && configSettingsChanged)
-				|| projectOptionsDifferFromWorkspace)) {
-			restartClangd();
+		if (done && LspUtils.isLsActive()
+				&& (((!projectScope().isPresent() || useProjectSettings()) && configSettingsChanged)
+						|| projectOptionsDifferFromWorkspace)) {
+			LspUtils.restartClangd();
 		}
 		return done;
-	}
-
-	private void restartClangd() {
-		LspUtils.getLanguageServers(false).forEach(w -> w.restart());
 	}
 
 	/**
@@ -84,11 +81,6 @@ public final class ClangdConfigurationPage extends ConfigurationPage<ClangdConfi
 	private boolean projectOptionsDifferFromWorkspace() {
 		return hasProjectSpecificOptions() != useProjectSettings()
 				&& ((ClangdConfigurationArea) area).optionsChanged(configuration.options(null));
-	}
-
-	private boolean isLsActive() {
-		return LspUtils.getLanguageServers(false).stream().findFirst().filter(w -> w.startupFailed() || w.isActive())
-				.isPresent();
 	}
 
 	@Override

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ContentAssistConfigurationArea.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ContentAssistConfigurationArea.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd.internal.ui;
+
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistMetadata;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistOptions;
+import org.eclipse.cdt.lsp.ui.ConfigurationArea;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.OsgiPreferenceMetadataStore;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+
+public final class ContentAssistConfigurationArea extends ConfigurationArea<ClangdContentAssistOptions> {
+
+	private final Button fillFunctionArguments;
+	private final Group group;
+
+	public ContentAssistConfigurationArea(Composite parent, boolean isProjectScope) {
+		super(1);
+		Composite composite = new Composite(parent, SWT.NONE);
+		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		composite.setLayout(GridLayoutFactory.fillDefaults().numColumns(columns).create());
+		this.group = createGroup(composite, LspEditorUiMessages.ContentAssistConfigurationPage_insertion_group_name, 3);
+		this.fillFunctionArguments = createButton(ClangdContentAssistMetadata.fillFunctionArguments, group, SWT.CHECK,
+				0);
+	}
+
+	@Override
+	public void load(ClangdContentAssistOptions options, boolean enable) {
+		fillFunctionArguments.setSelection(options.fillFunctionArguments());
+		fillFunctionArguments.setEnabled(enable);
+	}
+
+	@Override
+	public void store(IEclipsePreferences prefs) {
+		OsgiPreferenceMetadataStore store = new OsgiPreferenceMetadataStore(prefs);
+		buttons.entrySet().forEach(e -> store.save(e.getValue().getSelection(), e.getKey()));
+	}
+
+	public boolean optionsChanged(ClangdContentAssistOptions options) {
+		return options.fillFunctionArguments() != fillFunctionArguments.getSelection();
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ContentAssistConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ContentAssistConfigurationPage.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.clangd.internal.ui;
+
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdContentAssistOptions;
+import org.eclipse.cdt.lsp.ui.ConfigurationArea;
+import org.eclipse.cdt.lsp.ui.ConfigurationPage;
+import org.eclipse.cdt.lsp.util.LspUtils;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+
+public final class ContentAssistConfigurationPage
+		extends ConfigurationPage<ClangdContentAssistConfiguration, ClangdContentAssistOptions> {
+	private final String id = "org.eclipse.cdt.lsp.clangd.editor.contentAssistPreferencePage"; //$NON-NLS-1$
+
+	@Override
+	protected ClangdContentAssistConfiguration getConfiguration(IWorkbench workbench) {
+		return workbench.getService(ClangdContentAssistConfiguration.class);
+	}
+
+	@Override
+	protected ClangdContentAssistOptions configurationDefaults() {
+		return configuration.defaults();
+	}
+
+	@Override
+	protected ClangdContentAssistOptions configurationOptions(IAdaptable element) {
+		return configuration.options(element);
+	}
+
+	@Override
+	protected ConfigurationArea<ClangdContentAssistOptions> getConfigurationArea(Composite composite,
+			boolean isProjectScope) {
+		return new ContentAssistConfigurationArea(composite, isProjectScope);
+	}
+
+	@Override
+	protected String getPreferenceId() {
+		return id;
+	}
+
+	@Override
+	public boolean performOk() {
+		var settingsChanged = configurationSettingsChanged(); // must be called prior to super.performOK(), otherwise we cannot detect pref changes.
+		var done = super.performOk();
+		if (done && isLsActive() && settingsChanged) {
+			restartClangd();
+		}
+		return done;
+	}
+
+	private boolean isLsActive() {
+		return LspUtils.getLanguageServers(false).stream().findFirst().filter(w -> w.startupFailed() || w.isActive())
+				.isPresent();
+	}
+
+	private void restartClangd() {
+		LspUtils.getLanguageServers(false).forEach(w -> w.restart());
+	}
+
+	/**
+	 * Returns true when the page settings differ from the stored.
+	 * @return
+	 */
+	private boolean configurationSettingsChanged() {
+		return ((ContentAssistConfigurationArea) area).optionsChanged(configuration.options(getElement()));
+	}
+
+	@Override
+	protected boolean hasProjectSpecificOptions() {
+		// We support only workspace wide settings for content assist. Because we currently only support a single LS for the whole workspace.
+		return false;
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ContentAssistConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ContentAssistConfigurationPage.java
@@ -54,19 +54,10 @@ public final class ContentAssistConfigurationPage
 	public boolean performOk() {
 		var settingsChanged = configurationSettingsChanged(); // must be called prior to super.performOK(), otherwise we cannot detect pref changes.
 		var done = super.performOk();
-		if (done && isLsActive() && settingsChanged) {
-			restartClangd();
+		if (done && LspUtils.isLsActive() && settingsChanged) {
+			LspUtils.restartClangd();
 		}
 		return done;
-	}
-
-	private boolean isLsActive() {
-		return LspUtils.getLanguageServers(false).stream().findFirst().filter(w -> w.startupFailed() || w.isActive())
-				.isPresent();
-	}
-
-	private void restartClangd() {
-		LspUtils.getLanguageServers(false).forEach(w -> w.restart());
 	}
 
 	/**

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/LspEditorUiMessages.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/LspEditorUiMessages.java
@@ -50,4 +50,8 @@ public class LspEditorUiMessages extends NLS {
 	public static String ClangFormatConfigurationPage_openProjectFormatFile;
 	public static String ClangFormatConfigurationPage_openFormatFileTooltip;
 
+	public static String ContentAssistConfigurationPage_fill_function_arguments;
+	public static String ContentAssistConfigurationPage_fill_function_arguments_description;
+	public static String ContentAssistConfigurationPage_insertion_group_name;
+
 }

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/LspEditorUiMessages.properties
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/LspEditorUiMessages.properties
@@ -37,3 +37,7 @@ LspEditorPreferencePage_Validate_clangd_options_description=Validates all clangd
 
 ClangFormatConfigurationPage_openProjectFormatFile=Open ClangFormat Configuration File...
 ClangFormatConfigurationPage_openFormatFileTooltip=Opens the .clang-format file
+
+ContentAssistConfigurationPage_fill_function_arguments=Fill function arguments and show guessed arguments
+ContentAssistConfigurationPage_fill_function_arguments_description=When disabled, completions contain only parentheses for function calls. When enabled, completions also contain guessed placeholders for function parameters
+ContentAssistConfigurationPage_insertion_group_name=Insertion

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.properties
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.properties
@@ -15,7 +15,7 @@ NavigatorView_ErrorOnLoad = Loading the symbols encountered an error; see the Er
 
 LspEditorConfigurationPage_spelling_link=Spelling preferences are set via <a href="org.eclipse.ui.editors.preferencePages.Spelling">Text Editors Spelling</a>.
 LspEditorConfigurationPage_spelling_link_tooltip=Show the shared text editor spelling preferences
-LspEditorConfigurationPage_content_assist_link=Content Assist preferences are set via <a href="org.eclipse.ui.genericeditor.GenericTextEditor">Generic Text Editors</a>.
+LspEditorConfigurationPage_content_assist_link=General Content Assist preferences are set via <a href="org.eclipse.ui.genericeditor.GenericTextEditor">Generic Text Editors</a>.
 LspEditorConfigurationPage_content_assist_link_tooltip=Show the generic text editors content assist preferences
 
 LspEditorConfigurationPage_enable_project_specific=Enable project-specific settings

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/util/LspUtils.java
@@ -205,4 +205,13 @@ public class LspUtils {
 				.filter(w -> "org.eclipse.cdt.lsp.server".equals(w.serverDefinition.id)).toList(); //$NON-NLS-1$
 	}
 
+	public static boolean isLsActive() {
+		return getLanguageServers(false).stream().findFirst().filter(w -> w.startupFailed() || w.isActive())
+				.isPresent();
+	}
+
+	public static void restartClangd() {
+		getLanguageServers(false).forEach(w -> w.restart());
+	}
+
 }


### PR DESCRIPTION
with `Fill function arguments and show guessed arguments` option to comply with old C/C++ editor Content Assist preference page. The option is only available on workspace level (preference page only) since we currently support only a single LS per workspace.

fixes #418