### PR TITLE
[#410] Evolve options API without bumping major version every time

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdMetadata.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangdMetadata.java
@@ -32,154 +32,143 @@ import org.eclipse.core.runtime.preferences.PreferenceMetadata;
 public interface ClangdMetadata extends ConfigurationMetadata {
 
 	/**
-	 * The predefined metadata for the "Clangd path" option.
-	 *
-	 * @see ClangdOptions#clangdPath()
+	 * Predefined preference metadata
 	 *
 	 * @since 3.0
+	 *
+	 * @noextend This interface is not intended to be extended by clients.
+	 * @noimplement This interface is not intended to be implemented by clients.
 	 */
-	PreferenceMetadata<String> clangdPath = new PreferenceMetadata<>(String.class, //
-			"clangd_path", //$NON-NLS-1$
-			Optional.ofNullable(PathUtil.findProgramLocation("clangd", null)) //$NON-NLS-1$
-					.map(IPath::toOSString).orElse("clangd"), //$NON-NLS-1$
-			LspEditorUiMessages.LspEditorPreferencePage_path, //
-			LspEditorUiMessages.LspEditorPreferencePage_path_description);
+	interface Predefined {
+		/**
+		 * The predefined metadata for the "Clangd path" option.
+		 *
+		 * @see ClangdOptions#clangdPath()
+		 */
+		PreferenceMetadata<String> clangdPath = new PreferenceMetadata<>(String.class, //
+				"clangd_path", //$NON-NLS-1$
+				Optional.ofNullable(PathUtil.findProgramLocation("clangd", null)) //$NON-NLS-1$
+						.map(IPath::toOSString).orElse("clangd"), //$NON-NLS-1$
+				LspEditorUiMessages.LspEditorPreferencePage_path, //
+				LspEditorUiMessages.LspEditorPreferencePage_path_description);
 
-	/**
-	 * The predefined metadata for the "Enable clang-tidy" option.
-	 *
-	 * @see ClangdOptions#useTidy()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> useTidy = new PreferenceMetadata<>(Boolean.class, //
-			"use_tidy", //$NON-NLS-1$
-			true, //
-			LspEditorUiMessages.LspEditorPreferencePage_enable_tidy, //
-			LspEditorUiMessages.LspEditorPreferencePage_enable_tidy);
+		/**
+		 * The predefined metadata for the "Enable clang-tidy" option.
+		 *
+		 * @see ClangdOptions#useTidy()
+		 */
+		PreferenceMetadata<Boolean> useTidy = new PreferenceMetadata<>(Boolean.class, //
+				"use_tidy", //$NON-NLS-1$
+				true, //
+				LspEditorUiMessages.LspEditorPreferencePage_enable_tidy, //
+				LspEditorUiMessages.LspEditorPreferencePage_enable_tidy);
 
-	/**
-	 * The predefined metadata for the "Background index" option.
-	 *
-	 * @see ClangdOptions#useBackgroundIndex()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> useBackgroundIndex = new PreferenceMetadata<>(Boolean.class, //
-			"background_index", //$NON-NLS-1$
-			true, //
-			LspEditorUiMessages.LspEditorPreferencePage_background_index, //
-			LspEditorUiMessages.LspEditorPreferencePage_background_index);
+		/**
+		 * The predefined metadata for the "Background index" option.
+		 *
+		 * @see ClangdOptions#useBackgroundIndex()
+		 */
+		PreferenceMetadata<Boolean> useBackgroundIndex = new PreferenceMetadata<>(Boolean.class, //
+				"background_index", //$NON-NLS-1$
+				true, //
+				LspEditorUiMessages.LspEditorPreferencePage_background_index, //
+				LspEditorUiMessages.LspEditorPreferencePage_background_index);
 
-	/**
-	 * The predefined metadata for the "Completion style" option.
-	 *
-	 * @see ClangdOptions#completionStyle()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<String> completionStyle = new PreferenceMetadata<>(String.class, //
-			"completion_style", //$NON-NLS-1$
-			"detailed", //$NON-NLS-1$
-			LspEditorUiMessages.LspEditorPreferencePage_completion, //
-			LspEditorUiMessages.LspEditorPreferencePage_completion_description);
+		/**
+		 * The predefined metadata for the "Completion style" option.
+		 *
+		 * @see ClangdOptions#completionStyle()
+		 */
+		PreferenceMetadata<String> completionStyle = new PreferenceMetadata<>(String.class, //
+				"completion_style", //$NON-NLS-1$
+				"detailed", //$NON-NLS-1$
+				LspEditorUiMessages.LspEditorPreferencePage_completion, //
+				LspEditorUiMessages.LspEditorPreferencePage_completion_description);
 
-	/**
-	 * The predefined metadata for the "Pretty print" option.
-	 *
-	 * @see ClangdOptions#prettyPrint()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> prettyPrint = new PreferenceMetadata<>(Boolean.class, //
-			"pretty_print", //$NON-NLS-1$
-			true, //
-			LspEditorUiMessages.LspEditorPreferencePage_pretty_print, //
-			LspEditorUiMessages.LspEditorPreferencePage_pretty_print);
+		/**
+		 * The predefined metadata for the "Pretty print" option.
+		 *
+		 * @see ClangdOptions#prettyPrint()
+		 */
+		PreferenceMetadata<Boolean> prettyPrint = new PreferenceMetadata<>(Boolean.class, //
+				"pretty_print", //$NON-NLS-1$
+				true, //
+				LspEditorUiMessages.LspEditorPreferencePage_pretty_print, //
+				LspEditorUiMessages.LspEditorPreferencePage_pretty_print);
 
-	/**
-	 * The predefined metadata for the "Query driver" option.
-	 *
-	 * @see ClangdOptions#queryDriver()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<String> queryDriver = new PreferenceMetadata<>(String.class, //
-			"query_driver", //$NON-NLS-1$
-			Optional.ofNullable(PathUtil.findProgramLocation("gcc", null)) //$NON-NLS-1$
-					.map(p -> p.removeLastSegments(1).append(IPath.SEPARATOR + "*"))// //$NON-NLS-1$
-					.map(IPath::toString).orElse(""), //$NON-NLS-1$
-			LspEditorUiMessages.LspEditorPreferencePage_drivers, //
-			LspEditorUiMessages.LspEditorPreferencePage_drivers_description);
+		/**
+		 * The predefined metadata for the "Query driver" option.
+		 *
+		 * @see ClangdOptions#queryDriver()
+		 */
+		PreferenceMetadata<String> queryDriver = new PreferenceMetadata<>(String.class, //
+				"query_driver", //$NON-NLS-1$
+				Optional.ofNullable(PathUtil.findProgramLocation("gcc", null)) //$NON-NLS-1$
+						.map(p -> p.removeLastSegments(1).append(IPath.SEPARATOR + "*"))// //$NON-NLS-1$
+						.map(IPath::toString).orElse(""), //$NON-NLS-1$
+				LspEditorUiMessages.LspEditorPreferencePage_drivers, //
+				LspEditorUiMessages.LspEditorPreferencePage_drivers_description);
 
-	/**
-	 * The predefined metadata for the additional options, must not return <code>null</code>.
-	 *
-	 * @see ClangdOptions#additionalOptions
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<String> additionalOptions = new PreferenceMetadata<>(String.class, //
-			"additional_options", //$NON-NLS-1$
-			List.of("").stream().collect(Collectors.joining(System.lineSeparator())), //$NON-NLS-1$
-			LspEditorUiMessages.LspEditorPreferencePage_additional, //
-			LspEditorUiMessages.LspEditorPreferencePage_additional_description);
+		/**
+		 * The predefined metadata for the additional options, must not return <code>null</code>.
+		 *
+		 * @see ClangdOptions#additionalOptions
+		 */
+		PreferenceMetadata<String> additionalOptions = new PreferenceMetadata<>(String.class, //
+				"additional_options", //$NON-NLS-1$
+				List.of("").stream().collect(Collectors.joining(System.lineSeparator())), //$NON-NLS-1$
+				LspEditorUiMessages.LspEditorPreferencePage_additional, //
+				LspEditorUiMessages.LspEditorPreferencePage_additional_description);
 
-	/**
-	 * The predefined metadata for the "Log to Console" option.
-	 *
-	 * @see ClangdOptions#logToConsole()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> logToConsole = new PreferenceMetadata<>(Boolean.class, //
-			"log_to_console", //$NON-NLS-1$
-			false, //
-			LspEditorUiMessages.LspEditorPreferencePage_Log_to_Console, //
-			LspEditorUiMessages.LspEditorPreferencePage_Log_to_Console_description);
+		/**
+		 * The predefined metadata for the "Log to Console" option.
+		 *
+		 * @see ClangdOptions#logToConsole()
+		 */
+		PreferenceMetadata<Boolean> logToConsole = new PreferenceMetadata<>(Boolean.class, //
+				"log_to_console", //$NON-NLS-1$
+				false, //
+				LspEditorUiMessages.LspEditorPreferencePage_Log_to_Console, //
+				LspEditorUiMessages.LspEditorPreferencePage_Log_to_Console_description);
 
-	/**
-	 * The predefined metadata for the "Validate clangd options" option.
-	 *
-	 * @see ClangdOptions#validateClangdOptions()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> validateClangdOptions = new PreferenceMetadata<>(Boolean.class, //
-			"validate_clangd_options", //$NON-NLS-1$
-			true, //
-			LspEditorUiMessages.LspEditorPreferencePage_Validate_clangd_options, //
-			LspEditorUiMessages.LspEditorPreferencePage_Validate_clangd_options_description);
+		/**
+		 * The predefined metadata for the "Validate clangd options" option.
+		 *
+		 * @see ClangdOptions#validateClangdOptions()
+		 */
+		PreferenceMetadata<Boolean> validateClangdOptions = new PreferenceMetadata<>(Boolean.class, //
+				"validate_clangd_options", //$NON-NLS-1$
+				true, //
+				LspEditorUiMessages.LspEditorPreferencePage_Validate_clangd_options, //
+				LspEditorUiMessages.LspEditorPreferencePage_Validate_clangd_options_description);
 
-	/**
-	 * Returns the metadata for the "Fill function arguments and show guessed arguments" option.
-	 *
-	 * @see ClangdOptions#fillFunctionArguments()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> fillFunctionArguments = new PreferenceMetadata<>(Boolean.class, //
-			"fill_function_arguments", //$NON-NLS-1$
-			true, //
-			LspEditorUiMessages.ContentAssistConfigurationPage_fill_function_arguments,
-			LspEditorUiMessages.ContentAssistConfigurationPage_fill_function_arguments_description);
+		/**
+		 * Returns the metadata for the "Fill function arguments and show guessed arguments" option.
+		 *
+		 * @see ClangdOptions#fillFunctionArguments()
+		 */
+		PreferenceMetadata<Boolean> fillFunctionArguments = new PreferenceMetadata<>(Boolean.class, //
+				"fill_function_arguments", //$NON-NLS-1$
+				true, //
+				LspEditorUiMessages.ContentAssistConfigurationPage_fill_function_arguments,
+				LspEditorUiMessages.ContentAssistConfigurationPage_fill_function_arguments_description);
 
-	/**
-	 * Returns the default {@link List} of {@link PreferenceMetadata}
-	 *
-	 * @since 3.0
-	 */
-	List<PreferenceMetadata<?>> defaults = List.of(//
-			clangdPath, //
-			useTidy, //
-			useBackgroundIndex, //
-			completionStyle, //
-			prettyPrint, //
-			queryDriver, //
-			additionalOptions, //
-			logToConsole, //
-			validateClangdOptions, //
-			fillFunctionArguments//
-	);
+		/**
+		 * Returns the default {@link List} of {@link PreferenceMetadata}
+		 */
+		List<PreferenceMetadata<?>> defaults = List.of(//
+				clangdPath, //
+				useTidy, //
+				useBackgroundIndex, //
+				completionStyle, //
+				prettyPrint, //
+				queryDriver, //
+				additionalOptions, //
+				logToConsole, //
+				validateClangdOptions, //
+				fillFunctionArguments//
+		);
+
+	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdMetadataDefaults.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdMetadataDefaults.java
@@ -25,7 +25,7 @@ public final class ClangdMetadataDefaults extends ConfigurationMetadataBase impl
 
 	@Override
 	protected List<PreferenceMetadata<?>> definePreferences() {
-		return defaults;
+		return Predefined.defaults;
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdPreferredOptions.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdPreferredOptions.java
@@ -30,37 +30,37 @@ final class ClangdPreferredOptions extends PreferredOptions implements ClangdOpt
 
 	@Override
 	public String clangdPath() {
-		return stringValue(ClangdMetadata.clangdPath);
+		return stringValue(ClangdMetadata.Predefined.clangdPath);
 	}
 
 	@Override
 	public boolean useTidy() {
-		return booleanValue(ClangdMetadata.useTidy);
+		return booleanValue(ClangdMetadata.Predefined.useTidy);
 	}
 
 	@Override
 	public boolean useBackgroundIndex() {
-		return booleanValue(ClangdMetadata.useBackgroundIndex);
+		return booleanValue(ClangdMetadata.Predefined.useBackgroundIndex);
 	}
 
 	@Override
 	public String completionStyle() {
-		return stringValue(ClangdMetadata.completionStyle);
+		return stringValue(ClangdMetadata.Predefined.completionStyle);
 	}
 
 	@Override
 	public boolean prettyPrint() {
-		return booleanValue(ClangdMetadata.prettyPrint);
+		return booleanValue(ClangdMetadata.Predefined.prettyPrint);
 	}
 
 	@Override
 	public String queryDriver() {
-		return stringValue(ClangdMetadata.queryDriver);
+		return stringValue(ClangdMetadata.Predefined.queryDriver);
 	}
 
 	@Override
 	public List<String> additionalOptions() {
-		var options = stringValue(ClangdMetadata.additionalOptions);
+		var options = stringValue(ClangdMetadata.Predefined.additionalOptions);
 		if (options.isBlank()) {
 			return new ArrayList<>();
 		}
@@ -69,17 +69,17 @@ final class ClangdPreferredOptions extends PreferredOptions implements ClangdOpt
 
 	@Override
 	public boolean logToConsole() {
-		return booleanValue(ClangdMetadata.logToConsole);
+		return booleanValue(ClangdMetadata.Predefined.logToConsole);
 	}
 
 	@Override
 	public boolean validateClangdOptions() {
-		return booleanValue(ClangdMetadata.validateClangdOptions);
+		return booleanValue(ClangdMetadata.Predefined.validateClangdOptions);
 	}
 
 	@Override
 	public boolean fillFunctionArguments() {
-		return booleanValue(ClangdMetadata.fillFunctionArguments);
+		return booleanValue(ClangdMetadata.Predefined.fillFunctionArguments);
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationArea.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationArea.java
@@ -79,16 +79,16 @@ public final class ClangdConfigurationArea extends ConfigurationArea<ClangdOptio
 		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		composite.setLayout(GridLayoutFactory.fillDefaults().numColumns(columns).create());
 		this.group = createGroup(composite, LspEditorUiMessages.LspEditorPreferencePage_clangd_options_label, 3);
-		this.path = createFileSelector(ClangdMetadata.clangdPath, group, this::selectClangdExecutable);
-		this.tidy = createButton(ClangdMetadata.useTidy, group, SWT.CHECK, 0);
-		this.index = createButton(ClangdMetadata.useBackgroundIndex, group, SWT.CHECK, 0);
-		this.completion = createCombo(ClangdMetadata.completionStyle, group, completionsKeys);
-		this.pretty = createButton(ClangdMetadata.prettyPrint, group, SWT.CHECK, 0);
-		this.driver = createText(ClangdMetadata.queryDriver, group, false);
-		this.additional = createText(ClangdMetadata.additionalOptions, group, true);
+		this.path = createFileSelector(ClangdMetadata.Predefined.clangdPath, group, this::selectClangdExecutable);
+		this.tidy = createButton(ClangdMetadata.Predefined.useTidy, group, SWT.CHECK, 0);
+		this.index = createButton(ClangdMetadata.Predefined.useBackgroundIndex, group, SWT.CHECK, 0);
+		this.completion = createCombo(ClangdMetadata.Predefined.completionStyle, group, completionsKeys);
+		this.pretty = createButton(ClangdMetadata.Predefined.prettyPrint, group, SWT.CHECK, 0);
+		this.driver = createText(ClangdMetadata.Predefined.queryDriver, group, false);
+		this.additional = createText(ClangdMetadata.Predefined.additionalOptions, group, true);
 		if (!isProjectScope) {
-			this.logToConsole = createButton(ClangdMetadata.logToConsole, group, SWT.CHECK, 0);
-			this.validateOptions = createButton(ClangdMetadata.validateClangdOptions, group, SWT.CHECK, 0);
+			this.logToConsole = createButton(ClangdMetadata.Predefined.logToConsole, group, SWT.CHECK, 0);
+			this.validateOptions = createButton(ClangdMetadata.Predefined.validateClangdOptions, group, SWT.CHECK, 0);
 		} else {
 			this.logToConsole = null;
 			this.validateOptions = null;
@@ -209,15 +209,15 @@ public final class ClangdConfigurationArea extends ConfigurationArea<ClangdOptio
 	@Override
 	public List<String> getPreferenceKeys() {
 		var list = new ArrayList<String>(9);
-		list.add(ClangdMetadata.additionalOptions.identifer());
-		list.add(ClangdMetadata.clangdPath.identifer());
-		list.add(ClangdMetadata.completionStyle.identifer());
-		list.add(ClangdMetadata.logToConsole.identifer());
-		list.add(ClangdMetadata.prettyPrint.identifer());
-		list.add(ClangdMetadata.queryDriver.identifer());
-		list.add(ClangdMetadata.useBackgroundIndex.identifer());
-		list.add(ClangdMetadata.useTidy.identifer());
-		list.add(ClangdMetadata.validateClangdOptions.identifer());
+		list.add(ClangdMetadata.Predefined.additionalOptions.identifer());
+		list.add(ClangdMetadata.Predefined.clangdPath.identifer());
+		list.add(ClangdMetadata.Predefined.completionStyle.identifer());
+		list.add(ClangdMetadata.Predefined.logToConsole.identifer());
+		list.add(ClangdMetadata.Predefined.prettyPrint.identifer());
+		list.add(ClangdMetadata.Predefined.queryDriver.identifer());
+		list.add(ClangdMetadata.Predefined.useBackgroundIndex.identifer());
+		list.add(ClangdMetadata.Predefined.useTidy.identifer());
+		list.add(ClangdMetadata.Predefined.validateClangdOptions.identifer());
 		return list;
 	}
 

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ClangdConfigurationPage.java
@@ -87,7 +87,7 @@ public final class ClangdConfigurationPage extends ConfigurationPage<ClangdConfi
 	protected boolean hasProjectSpecificOptions() {
 		return projectScope()//
 				.map(p -> p.getNode(configuration.qualifier()))//
-				.map(n -> n.get(ClangdMetadata.clangdPath.identifer(), null))//
+				.map(n -> n.get(ClangdMetadata.Predefined.clangdPath.identifer(), null))//
 				.isPresent();
 	}
 

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ContentAssistConfigurationArea.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/ui/ContentAssistConfigurationArea.java
@@ -37,7 +37,7 @@ public final class ContentAssistConfigurationArea extends ConfigurationArea<Clan
 		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		composite.setLayout(GridLayoutFactory.fillDefaults().numColumns(columns).create());
 		this.group = createGroup(composite, LspEditorUiMessages.ContentAssistConfigurationPage_insertion_group_name, 3);
-		this.fillFunctionArguments = createButton(ClangdMetadata.fillFunctionArguments, group, SWT.CHECK, 0);
+		this.fillFunctionArguments = createButton(ClangdMetadata.Predefined.fillFunctionArguments, group, SWT.CHECK, 0);
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public final class ContentAssistConfigurationArea extends ConfigurationArea<Clan
 	@Override
 	public List<String> getPreferenceKeys() {
 		var list = new ArrayList<String>(1);
-		list.add(ClangdMetadata.fillFunctionArguments.identifer());
+		list.add(ClangdMetadata.Predefined.fillFunctionArguments.identifer());
 		return list;
 	}
 

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/TestUtils.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/TestUtils.java
@@ -41,7 +41,7 @@ public class TestUtils {
 
 	public static void setLspPreferred(IProject project, boolean value) {
 		ServiceCaller.callOnce(TestUtils.class, EditorConfiguration.class, //
-				cc -> cc.storage(project).save(value, EditorMetadata.preferLspEditor));
+				cc -> cc.storage(project).save(value, EditorMetadata.Predefined.preferLspEditor));
 	}
 
 	public static IProject createCProject(String projectName) throws CoreException {

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorMetadata.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorMetadata.java
@@ -12,6 +12,8 @@
 
 package org.eclipse.cdt.lsp.editor;
 
+import java.util.List;
+
 import org.eclipse.cdt.lsp.config.ConfigurationMetadata;
 import org.eclipse.cdt.lsp.internal.messages.LspUiMessages;
 import org.eclipse.core.runtime.preferences.PreferenceMetadata;
@@ -19,55 +21,65 @@ import org.eclipse.core.runtime.preferences.PreferenceMetadata;
 public interface EditorMetadata extends ConfigurationMetadata {
 
 	/**
-	 * The predefined metadata for the "Prefer C/C++ Editor (LSP)" option
-	 *
-	 * @see EditorOptions#preferLspEditor()
+	 * Predefined preference metadata
 	 *
 	 * @since 3.0
+	 *
+	 * @noextend This interface is not intended to be extended by clients.
+	 * @noimplement This interface is not intended to be implemented by clients.
 	 */
-	PreferenceMetadata<Boolean> preferLspEditor = new PreferenceMetadata<>(Boolean.class, //
-			"prefer_lsp", //$NON-NLS-1$
-			false, //
-			LspUiMessages.LspEditorConfigurationPage_preferLspEditor,
-			LspUiMessages.LspEditorConfigurationPage_preferLspEditor_description);
+	interface Predefined {
 
-	/**
-	 * The predefined metadata for the "Format source code" option
-	 *
-	 * @see EditorOptions#formatOnSave()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> formatOnSave = new PreferenceMetadata<>(Boolean.class, //
-			"format_source", //$NON-NLS-1$
-			false, //
-			LspUiMessages.SaveActionsConfigurationPage_FormatSourceCode,
-			LspUiMessages.SaveActionsConfigurationPage_FormatSourceCode_description);
+		/**
+		 * The predefined metadata for the "Prefer C/C++ Editor (LSP)" option
+		 *
+		 * @see EditorOptions#preferLspEditor()
+		 */
+		PreferenceMetadata<Boolean> preferLspEditor = new PreferenceMetadata<>(Boolean.class, //
+				"prefer_lsp", //$NON-NLS-1$
+				false, //
+				LspUiMessages.LspEditorConfigurationPage_preferLspEditor,
+				LspUiMessages.LspEditorConfigurationPage_preferLspEditor_description);
+		/**
+		 * The predefined metadata for the "Format source code" option
+		 *
+		 * @see EditorOptions#formatOnSave()
+		 */
+		PreferenceMetadata<Boolean> formatOnSave = new PreferenceMetadata<>(Boolean.class, //
+				"format_source", //$NON-NLS-1$
+				false, //
+				LspUiMessages.SaveActionsConfigurationPage_FormatSourceCode,
+				LspUiMessages.SaveActionsConfigurationPage_FormatSourceCode_description);
+		/**
+		 * The predefined metadata for the "Format all lines" option.
+		 *
+		 * @see EditorOptions#formatAllLines()
+		 */
+		PreferenceMetadata<Boolean> formatAllLines = new PreferenceMetadata<>(Boolean.class, //
+				"format_all_lines", //$NON-NLS-1$
+				true, //
+				LspUiMessages.SaveActionsConfigurationPage_FormatAllLines,
+				LspUiMessages.SaveActionsConfigurationPage_FormatAllLines_description);
+		/**
+		 * Returns the metadata for the "Format edited lines" option.
+		 *
+		 * @see EditorOptions#formatEditedLines()
+		 */
+		PreferenceMetadata<Boolean> formatEditedLines = new PreferenceMetadata<>(Boolean.class, //
+				"format_edited_lines", //$NON-NLS-1$
+				false, //
+				LspUiMessages.SaveActionsConfigurationPage_FormatEditedLines,
+				LspUiMessages.SaveActionsConfigurationPage_FormatEditedLines_description);
 
-	/**
-	 * The predefined metadata for the "Format all lines" option.
-	 *
-	 * @see EditorOptions#formatAllLines()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> formatAllLines = new PreferenceMetadata<>(Boolean.class, //
-			"format_all_lines", //$NON-NLS-1$
-			true, //
-			LspUiMessages.SaveActionsConfigurationPage_FormatAllLines,
-			LspUiMessages.SaveActionsConfigurationPage_FormatAllLines_description);
-
-	/**
-	 * Returns the metadata for the "Format edited lines" option.
-	 *
-	 * @see EditorOptions#formatEditedLines()
-	 *
-	 * @since 3.0
-	 */
-	PreferenceMetadata<Boolean> formatEditedLines = new PreferenceMetadata<>(Boolean.class, //
-			"format_edited_lines", //$NON-NLS-1$
-			false, //
-			LspUiMessages.SaveActionsConfigurationPage_FormatEditedLines,
-			LspUiMessages.SaveActionsConfigurationPage_FormatEditedLines_description);
+		/**
+		 * Returns the default {@link List} of {@link PreferenceMetadata}
+		 */
+		List<PreferenceMetadata<?>> defaults = List.of(//
+				preferLspEditor, //
+				formatOnSave, //
+				formatAllLines, //
+				formatEditedLines//
+		);
+	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/EditorMetadataDefaults.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/EditorMetadataDefaults.java
@@ -24,7 +24,7 @@ public final class EditorMetadataDefaults extends ConfigurationMetadataBase impl
 
 	@Override
 	protected List<PreferenceMetadata<?>> definePreferences() {
-		return List.of(preferLspEditor, formatOnSave, formatAllLines, formatEditedLines);
+		return Predefined.defaults;
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/EditorPreferredOptions.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/EditorPreferredOptions.java
@@ -30,22 +30,22 @@ public final class EditorPreferredOptions extends PreferredOptions implements Ed
 
 	@Override
 	public boolean preferLspEditor() {
-		return booleanValue(EditorMetadata.preferLspEditor);
+		return booleanValue(EditorMetadata.Predefined.preferLspEditor);
 	}
 
 	@Override
 	public boolean formatOnSave() {
-		return booleanValue(EditorMetadata.formatOnSave);
+		return booleanValue(EditorMetadata.Predefined.formatOnSave);
 	}
 
 	@Override
 	public boolean formatAllLines() {
-		return booleanValue(EditorMetadata.formatAllLines);
+		return booleanValue(EditorMetadata.Predefined.formatAllLines);
 	}
 
 	@Override
 	public boolean formatEditedLines() {
-		return booleanValue(EditorMetadata.formatEditedLines);
+		return booleanValue(EditorMetadata.Predefined.formatEditedLines);
 	}
 
 	@Override
@@ -53,7 +53,7 @@ public final class EditorPreferredOptions extends PreferredOptions implements Ed
 		if (enable != null) {
 			return enable.isEnabledFor(project);
 		}
-		return booleanValue(EditorMetadata.preferLspEditor);
+		return booleanValue(EditorMetadata.Predefined.preferLspEditor);
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/EditorConfigurationArea.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/EditorConfigurationArea.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.cdt.lsp.internal.ui;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.cdt.lsp.editor.ConfigurationVisibility;
@@ -41,7 +40,7 @@ public final class EditorConfigurationArea extends ConfigurationArea<EditorOptio
 		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		composite.setLayout(GridLayoutFactory.fillDefaults().numColumns(columns).create());
 		if (visibility.showPreferLsp(isProjectScope)) {
-			this.prefer = createButton(EditorMetadata.preferLspEditor, composite, SWT.CHECK, 0);
+			this.prefer = createButton(EditorMetadata.Predefined.preferLspEditor, composite, SWT.CHECK, 0);
 		} else {
 			this.prefer = null;
 		}
@@ -63,9 +62,7 @@ public final class EditorConfigurationArea extends ConfigurationArea<EditorOptio
 
 	@Override
 	public List<String> getPreferenceKeys() {
-		var list = new ArrayList<String>(1);
-		list.add(EditorMetadata.preferLspEditor.identifer());
-		return list;
+		return List.of(EditorMetadata.Predefined.preferLspEditor.identifer());
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/SaveActionsConfigurationArea.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/SaveActionsConfigurationArea.java
@@ -40,9 +40,9 @@ public final class SaveActionsConfigurationArea extends ConfigurationArea<Editor
 		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		composite.setLayout(GridLayoutFactory.fillDefaults().numColumns(columns).create());
 
-		this.format = createButton(EditorMetadata.formatOnSave, composite, SWT.CHECK, 0);
-		this.formatAll = createButton(EditorMetadata.formatAllLines, composite, SWT.RADIO, 15);
-		this.formatEdited = createButton(EditorMetadata.formatEditedLines, composite, SWT.RADIO, 15);
+		this.format = createButton(EditorMetadata.Predefined.formatOnSave, composite, SWT.CHECK, 0);
+		this.formatAll = createButton(EditorMetadata.Predefined.formatAllLines, composite, SWT.RADIO, 15);
+		this.formatEdited = createButton(EditorMetadata.Predefined.formatEditedLines, composite, SWT.RADIO, 15);
 
 		final SelectionAdapter formatListener = new SelectionAdapter() {
 			@Override
@@ -74,9 +74,9 @@ public final class SaveActionsConfigurationArea extends ConfigurationArea<Editor
 	@Override
 	public List<String> getPreferenceKeys() {
 		var list = new ArrayList<String>(3);
-		list.add(EditorMetadata.formatOnSave.identifer());
-		list.add(EditorMetadata.formatAllLines.identifer());
-		list.add(EditorMetadata.formatEditedLines.identifer());
+		list.add(EditorMetadata.Predefined.formatOnSave.identifer());
+		list.add(EditorMetadata.Predefined.formatAllLines.identifer());
+		list.add(EditorMetadata.Predefined.formatEditedLines.identifer());
 		return list;
 	}
 

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/SaveActionsConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/SaveActionsConfigurationPage.java
@@ -53,7 +53,7 @@ public final class SaveActionsConfigurationPage extends ConfigurationPage<Editor
 	protected boolean hasProjectSpecificOptions() {
 		return projectScope()//
 				.map(p -> p.getNode(configuration.qualifier()))//
-				.map(n -> n.get(EditorMetadata.formatAllLines.identifer(), null))//
+				.map(n -> n.get(EditorMetadata.Predefined.formatAllLines.identifer(), null))//
 				.isPresent();
 	}
 

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/EditorConfigurationPage.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/ui/EditorConfigurationPage.java
@@ -57,7 +57,7 @@ public final class EditorConfigurationPage extends ConfigurationPage<EditorConfi
 	protected boolean hasProjectSpecificOptions() {
 		return projectScope()//
 				.map(p -> p.getNode(configuration.qualifier()))//
-				.map(n -> n.get(EditorMetadata.preferLspEditor.identifer(), null))//
+				.map(n -> n.get(EditorMetadata.Predefined.preferLspEditor.identifer(), null))//
 				.isPresent();
 	}
 

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/src/org/eclipse/cdt/lsp/examples/preferences/MyClangdOptionsDefaults.java
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/src/org/eclipse/cdt/lsp/examples/preferences/MyClangdOptionsDefaults.java
@@ -26,7 +26,7 @@ public class MyClangdOptionsDefaults extends ConfigurationMetadataBase implement
 
 	@Override
 	protected List<PreferenceMetadata<?>> definePreferences() {
-		return overrideOne(defaults, overrideString(additionalOptions, //
+		return overrideOne(Predefined.defaults, overrideString(Predefined.additionalOptions, //
 				List.of("--header-insertion=never", "--default-config").stream()
 						.collect(Collectors.joining(System.lineSeparator()))));
 	}

--- a/tests/org.eclipse.cdt.lsp.clangd.tests/src/org/eclipse/cdt/lsp/clangd/tests/TestUtils.java
+++ b/tests/org.eclipse.cdt.lsp.clangd.tests/src/org/eclipse/cdt/lsp/clangd/tests/TestUtils.java
@@ -29,7 +29,7 @@ public final class TestUtils {
 
 	public static void setLspPreferred(IProject project, boolean value) {
 		ServiceCaller.callOnce(TestUtils.class, EditorConfiguration.class, //
-				cc -> cc.storage(project).save(value, EditorMetadata.preferLspEditor));
+				cc -> cc.storage(project).save(value, EditorMetadata.Predefined.preferLspEditor));
 	}
 
 	public static IProject createCProject(String projectName) throws CoreException {


### PR DESCRIPTION
* extract predefined preference metadata to another "noimplement" interface