### PR TITLE
Fix #436 Search .clang-format file in parent folders, before creating it

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
@@ -29,7 +29,8 @@ Require-Bundle: org.eclipse.cdt.lsp;bundle-version="0.0.0",
  org.eclipse.core.variables;bundle-version="0.0.0",
  org.yaml.snakeyaml;bundle-version="0.0.0",
  org.eclipse.tm4e.language_pack;bundle-version="0.0.0",
- org.eclipse.ui.console;bundle-version="0.0.0"
+ org.eclipse.ui.console;bundle-version="0.0.0",
+ org.eclipse.core.filesystem
 Service-Component: OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangFormatFileHandler.xml,
  OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdCommandLineValidator.xml,
  OSGI-INF/org.eclipse.cdt.lsp.clangd.internal.config.ClangdConfigurationAccess.xml,

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangFormatFile.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/ClangFormatFile.java
@@ -20,13 +20,15 @@ import org.eclipse.core.resources.IProject;
 public interface ClangFormatFile {
 
 	/**
-	 * Opens the .clang-format file in the given project. Creates a file with default values, if not yet existing prior to the opening.
+	 * Opens the .clang-format file in the given project or in one of its parent directories.
+	 * Creates a file with default values, if not yet existing prior to the opening.
 	 * @param formatFile
 	 */
 	void openClangFormatFile(IProject project);
 
 	/**
-	 * Creates a new .clang-format file with default settings in the project root directory if not yet existing.
+	 * Creates a new .clang-format file with default settings in the project root directory if not yet existing
+	 * or uses an existing file on one of the project's parent directories.
 	 * @param project
 	 */
 	void createClangFormatFile(IProject project);

--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/format/ClangFormatFileMonitor.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/format/ClangFormatFileMonitor.java
@@ -40,7 +40,7 @@ import org.eclipse.core.variables.VariablesPlugin;
  * to add error markers to the modified <code>.clang-format</code> file.
  */
 public class ClangFormatFileMonitor {
-	private static final String CLANG_FORMAT_FILE = ".clang-format"; //$NON-NLS-1$
+	public static final String CLANG_FORMAT_FILE = ".clang-format"; //$NON-NLS-1$
 	public static final String CLANG_FORMAT_CHECK_FILE = "clang-format-check"; //$NON-NLS-1$
 	private final ConcurrentLinkedQueue<IFile> pendingFiles = new ConcurrentLinkedQueue<>();
 	private final IWorkspace workspace;
@@ -76,13 +76,13 @@ public class ClangFormatFileMonitor {
 		this.workspace = workspace;
 	}
 
-	private final WorkspaceJob checkJob = new WorkspaceJob("Check .clang-format file") { //$NON-NLS-1$
+	private final WorkspaceJob checkJob = new WorkspaceJob("Check " + CLANG_FORMAT_FILE + " file") { //$NON-NLS-1$ //$NON-NLS-2$
 
 		@Override
 		public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
 			var clangdPath = getClangdPath();
 			if (clangdPath.isEmpty()) {
-				String msg = "Cannot determine clangd path for .clang-format file validation"; //$NON-NLS-1$
+				String msg = "Cannot determine clangd path for " + CLANG_FORMAT_FILE + " file validation"; //$NON-NLS-1$ //$NON-NLS-2$
 				Platform.getLog(getClass()).error(msg);
 				return Status.error(msg);
 			}


### PR DESCRIPTION
Instead of creating a .clang-format file for each project, CDT LSP now would check if there is a .clang-format file in some of the project's parent folders and use that. This way, multi-project directory structures (multi-project git repos) can offer common settings in their root folder that apply to all contained projects.