### PR TITLE
Add 2.0.0 and 3.0.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## CDT LSP Change Log
 
-### v1.0.0 (Sep 2023)
+### v3.0.0 (Mar 2024)
 
-- First release of CDT LSP
+Fixed issues: <https://github.com/eclipse-cdt/cdt-lsp/milestone/4?closed=1>
 
-Fixed issues: <https://github.com/eclipse-cdt/cdt-lsp/milestone/1?closed=1>
+### v2.0.0 (Jun 2024)
+
+Fixed issues: <https://github.com/eclipse-cdt/cdt-lsp/milestone/3?closed=1>
 
 ### v1.1.0 (Feb 2024)
 
@@ -14,3 +16,10 @@ Fixed issues: <https://github.com/eclipse-cdt/cdt-lsp/milestone/1?closed=1>
 - There is no API guarantee between 1.0.0 and 1.1.0. API stability will be added starting in a future release. See [#212](https://github.com/eclipse-cdt/cdt-lsp/issues/212)
 
 Fixed issues: <https://github.com/eclipse-cdt/cdt-lsp/milestone/2?closed=1>
+
+### v1.0.0 (Sep 2023)
+
+- First release of CDT LSP
+
+Fixed issues: <https://github.com/eclipse-cdt/cdt-lsp/milestone/1?closed=1>
+


### PR DESCRIPTION
I am not sure the ongoing value of this changelog, for now at least I have made it point back at the milestone's issues.