### PR TITLE
Prepare repo for CDT LSP 3.1.0

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.clangd/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.cdt.lsp.clangd
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.cdt.lsp.clangd;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.100.qualifier
 Export-Package: org.eclipse.cdt.lsp.clangd
 Import-Package: org.yaml.snakeyaml;version="1.27.0",
  org.yaml.snakeyaml.error;version="1.27.0",

--- a/bundles/org.eclipse.cdt.lsp.doc/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.doc/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.lsp.doc;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.100.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.lsp;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.100.qualifier
 Export-Package: org.eclipse.cdt.lsp,
  org.eclipse.cdt.lsp.config,
  org.eclipse.cdt.lsp.editor,

--- a/examples/org.eclipse.cdt.lsp.examples.preferences/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.cdt.lsp.examples.preferences/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.lsp.examples.preferences;singleton:=true
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.100.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.cdt.lsp.clangd,

--- a/features/org.eclipse.cdt.lsp.feature/feature.xml
+++ b/features/org.eclipse.cdt.lsp.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.lsp.feature"
       label="%featureName"
-      version="3.0.0.qualifier"
+      version="3.1.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.eclipse.cdt.lsp</groupId>
  <artifactId>org.eclipse.cdt.lsp.root</artifactId>
- <version>2.1.0-SNAPSHOT</version>
+ <version>3.1.0-SNAPSHOT</version>
  <packaging>pom</packaging>
 
  <properties>
@@ -22,8 +22,8 @@
   <cbi-plugins.version>1.4.3</cbi-plugins.version>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   <tycho.scmUrl>scm:git:https://github.com/eclipse-cdt/cdt-lsp</tycho.scmUrl>
-  <comparator.repo>https://download.eclipse.org/tools/cdt/releases/cdt-lsp-2.0/cdt-lsp-2.0.0/</comparator.repo>
-  <api-baseline.repo>https://download.eclipse.org/tools/cdt/releases/cdt-lsp-2.0/cdt-lsp-2.0.0/</api-baseline.repo>
+  <comparator.repo>https://download.eclipse.org/tools/cdt/releases/cdt-lsp-3.0/cdt-lsp-3.0.0/</comparator.repo>
+  <api-baseline.repo>https://download.eclipse.org/tools/cdt/releases/cdt-lsp-3.0/cdt-lsp-3.0.0/</api-baseline.repo>
   <api-baseline.repo.simrel>https://download.eclipse.org/releases/2024-06/</api-baseline.repo.simrel>
     <!-- these parameters are to control baseline replace and compare. On a local build you want
        to avoid baseline replace and compare, especially if you have different versions of Java than

--- a/releng/org.eclipse.cdt.lsp.repository/pom.xml
+++ b/releng/org.eclipse.cdt.lsp.repository/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.eclipse.cdt.lsp</groupId>
     <artifactId>org.eclipse.cdt.lsp.root</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <version>2.1.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <artifactId>org.eclipse.cdt.lsp.repository</artifactId>
   <packaging>eclipse-repository</packaging>
 


### PR DESCRIPTION
~Note that the MANIFEST.MF versions are not bumped - they should only be changed along with API changes following semantic version conventions.~

Scratch that - because we don't have jgit timestamps enabled the qualifier is just the build timestamp. Which means all bundles need to be bumped. For the branch that means +0.0.1, for the main that means +0.0.100. 