### PR TITLE
[#469] parse all yaml documents in .clangd file

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdConfigFileChecker.java
+++ b/bundles/org.eclipse.cdt.lsp.clangd/src/org/eclipse/cdt/lsp/clangd/internal/config/ClangdConfigFileChecker.java
@@ -43,7 +43,8 @@ public class ClangdConfigFileChecker {
 			try {
 				removeMarkerFromClangdConfig(configFile);
 				//throws ScannerException and ParserException:
-				yaml.load(inputStream);
+				yaml.loadAll(inputStream).forEach(doc -> {
+				});
 			} catch (MarkedYAMLException yamlException) {
 				// re-read the file, because the buffer which comes along with MarkedYAMLException is limited to ~800 bytes.
 				try (var reReadStream = configFile.getContents()) {


### PR DESCRIPTION
Do not throw an exception when starting a new document in .clangd file via ---.

fixes #469