### PR TITLE
[#497] bind F12 to Open Hyperlink in MS Visual Studio scheme

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.cdt.lsp/OSGI-INF/l10n/bundle.properties
@@ -15,7 +15,7 @@
 Bundle-Vendor = Eclipse CDT
 Bundle-Name = Language Server based C/C++ Editor
 Bundle-Copyright =\
-Copyright (c) 2023 Bachmann electronic GmbH and others.\n\
+Copyright (c) 2023, 2025 Bachmann electronic GmbH and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\
@@ -26,6 +26,7 @@ SPDX-License-Identifier: EPL-2.0\n\
 SaveActionsPreferencePage.name=Save Actions
 EditorPreferencePage.name=Editor (LSP)
 CEditor.name=C/C++ Editor (LSP)
+CEditor.description=Editor (LSP) for C/C++ Source Files
 Server.name=C/C++ Language Server
 Logger.name=Log Provider for C/C++ Language Server
 SymbolsLabelProvider.name=LS Symbols

--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -99,6 +99,12 @@
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="Ctrl+7">
       </key>
+      <key
+            commandId="org.eclipse.ui.edit.text.open.hyperlink"
+            contextId="org.eclipse.cdt.lsp.cEditorContext"
+            schemeId="org.eclipse.cdt.ui.visualstudio"
+            sequence="F12">
+      </key>
    </extension>
    <extension
          point="org.eclipse.ui.ide.editorAssociationOverride">
@@ -426,6 +432,15 @@
                type="org.eclipse.cdt.debug.internal.ui.actions.IMoveToLineTarget">
          </adapter>
       </factory>
+   </extension>
+   <extension
+         point="org.eclipse.ui.contexts">
+      <context
+            description="%CEditor.description"
+            id="org.eclipse.cdt.lsp.cEditorContext"
+            name="%CEditor.name"
+            parentId="org.eclipse.ui.genericeditor.genericEditorContext">
+      </context>
    </extension>  
 </plugin>
 

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CLspEditor.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CLspEditor.java
@@ -21,6 +21,12 @@ import org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor;
 
 @SuppressWarnings("restriction")
 public class CLspEditor extends ExtensionBasedTextEditor {
+	private static final String CONTEXT_ID = "org.eclipse.cdt.lsp.cEditorContext"; //$NON-NLS-1$
+
+	@Override
+	protected void initializeKeyBindingScopes() {
+		setKeyBindingScopes(new String[] { CONTEXT_ID });
+	}
 
 	@Override
 	protected ISourceViewer createSourceViewer(Composite parent, IVerticalRuler ruler, int styles) {


### PR DESCRIPTION
- introduce and use own context for C/C++ Editor (LSP)

fixes #497