### PR TITLE
Make sure we build release against released versions of dependencies

### DIFF
--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -15,26 +15,17 @@
 			<unit id="org.eclipse.unittest.ui" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/mylyn/updates/release/latest/" />
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/egit/updates" />
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/linuxtools/updates-docker-nightly" />
+			<repository location="https://download.eclipse.org/linuxtools/update-docker-5.18.1/" />
 			<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/snapshots/" />
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.27.4" />
 			<unit id="org.eclipse.lsp4e" version="0.0.0" />
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.mylyn.wikitext" version="0.0.0"/>
-			<unit id="org.eclipse.mylyn.wikitext.markdown" version="0.0.0"/>
-			<unit id="org.eclipse.mylyn.wikitext.markdown.ui" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/mylyn/updates/release/latest/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/" />
@@ -46,17 +37,14 @@
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tm4e/snapshots/" />
+			<repository location="https://download.eclipse.org/tm4e/releases/latest/" />
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<!-- We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace. -->
-			<repository location="https://download.eclipse.org/tools/cdt/builds/cdt/main/"/>
+			<repository location="https://download.eclipse.org/tools/cdt/releases/12.0/cdt-12.0.0/"/>
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/latest/" />
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="DirectFromMaven" missingManifest="error" type="Maven">
 			<dependencies>


### PR DESCRIPTION
Note that we aren't using latest versions of dependencies because we want CDT LSP to work against slightly older Eclipse installs.