### PR TITLE
[#561] support sub-word navigation

### DIFF
--- a/bundles/org.eclipse.cdt.lsp/.settings/.api_filters
+++ b/bundles/org.eclipse.cdt.lsp/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.cdt.lsp" version="2">
+    <resource path="src/org/eclipse/cdt/lsp/editor/EditorOptions.java" type="org.eclipse.cdt.lsp.editor.EditorOptions">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.lsp.editor.EditorOptions"/>
+                <message_argument value="enableSubWordNavigation()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.lsp;singleton:=true
-Bundle-Version: 3.0.500.qualifier
+Bundle-Version: 3.1.0.qualifier
 Export-Package: org.eclipse.cdt.lsp,
  org.eclipse.cdt.lsp.config,
  org.eclipse.cdt.lsp.editor,

--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.lsp;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 3.0.500.qualifier
 Export-Package: org.eclipse.cdt.lsp,
  org.eclipse.cdt.lsp.config,
  org.eclipse.cdt.lsp.editor,

--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.lsp;singleton:=true
-Bundle-Version: 3.0.400.qualifier
+Bundle-Version: 4.0.0.qualifier
 Export-Package: org.eclipse.cdt.lsp,
  org.eclipse.cdt.lsp.config,
  org.eclipse.cdt.lsp.editor,

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorMetadata.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorMetadata.java
@@ -59,7 +59,7 @@ public interface EditorMetadata extends ConfigurationMetadata {
 		 *
 		 * @see EditorOptions#enableSubWordNavigation()
 		 *
-		 * @since 4.0
+		 * @since 3.0
 		 */
 		PreferenceMetadata<Boolean> enableSubWordNavigation = new PreferenceMetadata<>(Boolean.class, //
 				"sub_word_navigation", //$NON-NLS-1$

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorMetadata.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorMetadata.java
@@ -55,6 +55,19 @@ public interface EditorMetadata extends ConfigurationMetadata {
 				LspUiMessages.LspEditorConfigurationPage_showTryLspBanner_description);
 
 		/**
+		 * The predefined metadata for the "Smart caret positioning in identifiers" option
+		 *
+		 * @see EditorOptions#enableSubWordNavigation()
+		 *
+		 * @since 4.0
+		 */
+		PreferenceMetadata<Boolean> enableSubWordNavigation = new PreferenceMetadata<>(Boolean.class, //
+				"sub_word_navigation", //$NON-NLS-1$
+				true, //
+				LspUiMessages.LspEditorConfigurationPage_enableSubWordNavigation,
+				LspUiMessages.LspEditorConfigurationPage_enableSubWordNavigation_description);
+
+		/**
 		 * The predefined metadata for the "Format source code" option
 		 *
 		 * @see EditorOptions#formatOnSave()
@@ -93,6 +106,7 @@ public interface EditorMetadata extends ConfigurationMetadata {
 		List<PreferenceMetadata<?>> defaults = List.of(//
 				preferLspEditor, //
 				showTryLspBanner, //
+				enableSubWordNavigation, //
 				formatOnSave, //
 				formatAllLines, //
 				formatEditedLines//

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorMetadata.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorMetadata.java
@@ -59,7 +59,7 @@ public interface EditorMetadata extends ConfigurationMetadata {
 		 *
 		 * @see EditorOptions#enableSubWordNavigation()
 		 *
-		 * @since 3.0
+		 * @since 3.1
 		 */
 		PreferenceMetadata<Boolean> enableSubWordNavigation = new PreferenceMetadata<>(Boolean.class, //
 				"sub_word_navigation", //$NON-NLS-1$

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorOptions.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorOptions.java
@@ -33,7 +33,7 @@ public interface EditorOptions {
 	 * Enable sub-word navigation in the editor
 	 *
 	 * @return if sub-word navigation should be enabled
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	default boolean enableSubWordNavigation() {
 		return true;

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorOptions.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -28,6 +28,14 @@ public interface EditorOptions {
 	 * @since 3.0
 	 */
 	boolean showTryLspBanner();
+
+	/**
+	 * Enable sub-word navigation in the editor
+	 *
+	 * @return if sub-word navigation should be enabled
+	 * @since 4.0
+	 */
+	boolean enableSubWordNavigation();
 
 	/**
 	 * Format source code on file save action

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorOptions.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/editor/EditorOptions.java
@@ -33,9 +33,11 @@ public interface EditorOptions {
 	 * Enable sub-word navigation in the editor
 	 *
 	 * @return if sub-word navigation should be enabled
-	 * @since 4.0
+	 * @since 3.0
 	 */
-	boolean enableSubWordNavigation();
+	default boolean enableSubWordNavigation() {
+		return true;
+	}
 
 	/**
 	 * Format source code on file save action

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CLspEditor.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CLspEditor.java
@@ -11,17 +11,459 @@
 
 package org.eclipse.cdt.lsp.internal.editor;
 
+import java.text.BreakIterator;
+import java.text.CharacterIterator;
+
+import org.eclipse.cdt.internal.ui.text.CWordIterator;
+import org.eclipse.cdt.internal.ui.text.DocumentCharacterIterator;
+import org.eclipse.cdt.lsp.editor.EditorConfiguration;
+import org.eclipse.cdt.lsp.editor.EditorOptions;
 import org.eclipse.cdt.lsp.internal.switchtolsp.ISwitchBackToTraditional;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.SafeRunner;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.IVerticalRuler;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ST;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor;
+import org.eclipse.ui.texteditor.ITextEditorActionDefinitionIds;
+import org.eclipse.ui.texteditor.IUpdate;
+import org.eclipse.ui.texteditor.TextNavigationAction;
 
 @SuppressWarnings("restriction")
 public class CLspEditor extends ExtensionBasedTextEditor {
+
+	/**
+	 * Text navigation action to navigate to the next sub-word.
+	 *
+	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+	 *
+	 * @since 4.0
+	 */
+	protected abstract class NextSubWordAction extends TextNavigationAction {
+		protected CWordIterator fIterator = new CWordIterator();
+
+		/**
+		 * Creates a new next sub-word action.
+		 *
+		 * @param code Action code for the default operation. Must be an action code from @see org.eclipse.swt.custom.ST.
+		 * @since 4.0
+		 */
+		protected NextSubWordAction(int code) {
+			super(getSourceViewer().getTextWidget(), code);
+		}
+
+		@Override
+		public void run() {
+			// Check whether sub word navigation is enabled.
+			if (!getOptionEnableSubWordNavigation()) {
+				super.run();
+				return;
+			}
+
+			final ISourceViewer viewer = getSourceViewer();
+			final IDocument document = viewer.getDocument();
+			fIterator.setText((CharacterIterator) new DocumentCharacterIterator(document));
+			int position = widgetOffset2ModelOffset(viewer, viewer.getTextWidget().getCaretOffset());
+			if (position == -1)
+				return;
+
+			int next = findNextPosition(position);
+			try {
+				if (isBlockSelectionModeEnabled()
+						&& document.getLineOfOffset(next) != document.getLineOfOffset(position)) {
+					super.run(); // may navigate into virtual white space
+				} else if (next != BreakIterator.DONE) {
+					setCaretPosition(next);
+					getTextWidget().showSelection();
+					fireSelectionChanged();
+				}
+			} catch (BadLocationException x) {
+				// ignore
+			}
+		}
+
+		/**
+		 * Finds the next position after the given position.
+		 *
+		 * @param position the current position
+		 * @return the next position
+		 */
+		protected int findNextPosition(int position) {
+			ISourceViewer viewer = getSourceViewer();
+			int widget = -1;
+			while (position != BreakIterator.DONE && widget == -1) { // TODO: optimize
+				position = fIterator.following(position);
+				if (position != BreakIterator.DONE)
+					widget = modelOffset2WidgetOffset(viewer, position);
+			}
+			return position;
+		}
+
+		/**
+		 * Sets the caret position to the sub-word boundary given with {@code position}.
+		 *
+		 * @param position Position where the action should move the caret
+		 */
+		protected abstract void setCaretPosition(int position);
+	}
+
+	/**
+	 * Text navigation action to navigate to the next sub-word.
+	 *
+	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+	 *
+	 * @since 4.0
+	 */
+	protected class NavigateNextSubWordAction extends NextSubWordAction {
+		/**
+		 * Creates a new navigate next sub-word action.
+		 */
+		public NavigateNextSubWordAction() {
+			super(ST.WORD_NEXT);
+		}
+
+		@Override
+		protected void setCaretPosition(final int position) {
+			getTextWidget().setCaretOffset(modelOffset2WidgetOffset(getSourceViewer(), position));
+		}
+	}
+
+	/**
+	 * Text operation action to delete the next sub-word.
+	 *
+	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+	 *
+	 * @since 4.0
+	 */
+	protected class DeleteNextSubWordAction extends NextSubWordAction implements IUpdate {
+		/**
+		 * Creates a new delete next sub-word action.
+		 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+		 */
+		public DeleteNextSubWordAction() {
+			super(ST.DELETE_WORD_NEXT);
+		}
+
+		@Override
+		protected void setCaretPosition(final int position) {
+			if (!validateEditorInputState())
+				return;
+
+			final ISourceViewer viewer = getSourceViewer();
+			StyledText text = viewer.getTextWidget();
+			Point widgetSelection = text.getSelection();
+			if (isBlockSelectionModeEnabled() && widgetSelection.y != widgetSelection.x) {
+				final int caret = text.getCaretOffset();
+				final int offset = modelOffset2WidgetOffset(viewer, position);
+
+				if (caret == widgetSelection.x)
+					text.setSelectionRange(widgetSelection.y, offset - widgetSelection.y);
+				else
+					text.setSelectionRange(widgetSelection.x, offset - widgetSelection.x);
+				text.invokeAction(ST.DELETE_NEXT);
+			} else {
+				Point selection = viewer.getSelectedRange();
+				final int caret, length;
+				if (selection.y != 0) {
+					caret = selection.x;
+					length = selection.y;
+				} else {
+					caret = widgetOffset2ModelOffset(viewer, text.getCaretOffset());
+					length = position - caret;
+				}
+
+				try {
+					viewer.getDocument().replace(caret, length, ""); //$NON-NLS-1$
+				} catch (BadLocationException e) {
+					// Should not happen
+				}
+			}
+		}
+
+		@Override
+		protected int findNextPosition(int position) {
+			return fIterator.following(position);
+		}
+
+		@Override
+		public void update() {
+			setEnabled(isEditorInputModifiable());
+		}
+	}
+
+	/**
+	 * Text operation action to select the next sub-word.
+	 *
+	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+	 *
+	 * @since 4.0
+	 */
+	protected class SelectNextSubWordAction extends NextSubWordAction {
+		/**
+		 * Creates a new select next sub-word action.
+		 */
+		public SelectNextSubWordAction() {
+			super(ST.SELECT_WORD_NEXT);
+		}
+
+		@Override
+		protected void setCaretPosition(final int position) {
+			final ISourceViewer viewer = getSourceViewer();
+
+			final StyledText text = viewer.getTextWidget();
+			if (text != null && !text.isDisposed()) {
+
+				final Point selection = text.getSelection();
+				final int caret = text.getCaretOffset();
+				final int offset = modelOffset2WidgetOffset(viewer, position);
+
+				if (caret == selection.x)
+					text.setSelectionRange(selection.y, offset - selection.y);
+				else
+					text.setSelectionRange(selection.x, offset - selection.x);
+			}
+		}
+	}
+
+	/**
+	 * Text navigation action to navigate to the previous sub-word.
+	 *
+	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+	 *
+	 * @since 4.0
+	 */
+	protected abstract class PreviousSubWordAction extends TextNavigationAction {
+		protected CWordIterator fIterator = new CWordIterator();
+
+		/**
+		 * Creates a new previous sub-word action.
+		 *
+		 * @param code Action code for the default operation. Must be an action code from @see org.eclipse.swt.custom.ST.
+		 */
+		protected PreviousSubWordAction(final int code) {
+			super(getSourceViewer().getTextWidget(), code);
+		}
+
+		@Override
+		public void run() {
+			// Check whether sub word navigation is enabled.
+			if (!getOptionEnableSubWordNavigation()) {
+				super.run();
+				return;
+			}
+
+			final ISourceViewer viewer = getSourceViewer();
+			final IDocument document = viewer.getDocument();
+			fIterator.setText((CharacterIterator) new DocumentCharacterIterator(document));
+			int position = widgetOffset2ModelOffset(viewer, viewer.getTextWidget().getCaretOffset());
+			if (position == -1)
+				return;
+
+			int previous = findPreviousPosition(position);
+			try {
+				if (isBlockSelectionModeEnabled()
+						&& document.getLineOfOffset(previous) != document.getLineOfOffset(position)) {
+					super.run(); // may navigate into virtual white space
+				} else if (previous != BreakIterator.DONE) {
+					setCaretPosition(previous);
+					getTextWidget().showSelection();
+					fireSelectionChanged();
+				}
+			} catch (BadLocationException e) {
+				// ignore - getLineOfOffset failed
+			}
+		}
+
+		/**
+		 * Finds the previous position before the given position.
+		 *
+		 * @param position the current position
+		 * @return the previous position
+		 */
+		protected int findPreviousPosition(int position) {
+			ISourceViewer viewer = getSourceViewer();
+			int widget = -1;
+			while (position != BreakIterator.DONE && widget == -1) { // TODO: optimize
+				position = fIterator.preceding(position);
+				if (position != BreakIterator.DONE)
+					widget = modelOffset2WidgetOffset(viewer, position);
+			}
+			return position;
+		}
+
+		/**
+		 * Sets the caret position to the sub-word boundary given with {@code position}.
+		 *
+		 * @param position Position where the action should move the caret
+		 */
+		protected abstract void setCaretPosition(int position);
+	}
+
+	/**
+	 * Text navigation action to navigate to the previous sub-word.
+	 *
+	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+	 *
+	 * @since 4.0
+	 */
+	protected class NavigatePreviousSubWordAction extends PreviousSubWordAction {
+
+		/**
+		 * Creates a new navigate previous sub-word action.
+		 */
+		public NavigatePreviousSubWordAction() {
+			super(ST.WORD_PREVIOUS);
+		}
+
+		@Override
+		protected void setCaretPosition(final int position) {
+			getTextWidget().setCaretOffset(modelOffset2WidgetOffset(getSourceViewer(), position));
+		}
+	}
+
+	/**
+	 * Text operation action to delete the previous sub-word.
+	 *
+	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+	 *
+	 * @since 4.0
+	 */
+	protected class DeletePreviousSubWordAction extends PreviousSubWordAction implements IUpdate {
+		/**
+		 * Creates a new delete previous sub-word action.
+		 */
+		public DeletePreviousSubWordAction() {
+			super(ST.DELETE_WORD_PREVIOUS);
+		}
+
+		@Override
+		protected void setCaretPosition(int position) {
+			if (!validateEditorInputState())
+				return;
+
+			final int length;
+			final ISourceViewer viewer = getSourceViewer();
+			StyledText text = viewer.getTextWidget();
+			Point widgetSelection = text.getSelection();
+			if (isBlockSelectionModeEnabled() && widgetSelection.y != widgetSelection.x) {
+				final int caret = text.getCaretOffset();
+				final int offset = modelOffset2WidgetOffset(viewer, position);
+
+				if (caret == widgetSelection.x)
+					text.setSelectionRange(widgetSelection.y, offset - widgetSelection.y);
+				else
+					text.setSelectionRange(widgetSelection.x, offset - widgetSelection.x);
+				text.invokeAction(ST.DELETE_PREVIOUS);
+			} else {
+				Point selection = viewer.getSelectedRange();
+				if (selection.y != 0) {
+					position = selection.x;
+					length = selection.y;
+				} else {
+					length = widgetOffset2ModelOffset(viewer, text.getCaretOffset()) - position;
+				}
+
+				try {
+					viewer.getDocument().replace(position, length, ""); //$NON-NLS-1$
+				} catch (BadLocationException e) {
+					// Should not happen
+				}
+			}
+		}
+
+		@Override
+		protected int findPreviousPosition(int position) {
+			return fIterator.preceding(position);
+		}
+
+		@Override
+		public void update() {
+			setEnabled(isEditorInputModifiable());
+		}
+	}
+
+	/**
+	 * Text operation action to select the previous sub-word.
+	 *
+	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
+	 *
+	 * @since 4.0
+	 */
+	protected class SelectPreviousSubWordAction extends PreviousSubWordAction {
+		/**
+		 * Creates a new select previous sub-word action.
+		 */
+		public SelectPreviousSubWordAction() {
+			super(ST.SELECT_WORD_PREVIOUS);
+		}
+
+		@Override
+		protected void setCaretPosition(final int position) {
+			final ISourceViewer viewer = getSourceViewer();
+
+			final StyledText text = viewer.getTextWidget();
+			if (text != null && !text.isDisposed()) {
+				final Point selection = text.getSelection();
+				final int caret = text.getCaretOffset();
+				final int offset = modelOffset2WidgetOffset(viewer, position);
+
+				if (caret == selection.x) {
+					text.setSelectionRange(selection.y, offset - selection.y);
+				} else {
+					text.setSelectionRange(selection.x, offset - selection.x);
+				}
+			}
+		}
+	}
+
 	private static final String CONTEXT_ID = "org.eclipse.cdt.lsp.cEditorContext"; //$NON-NLS-1$
+
+	@Override
+	protected void createNavigationActions() {
+		super.createNavigationActions();
+
+		final StyledText textWidget = getSourceViewer().getTextWidget();
+
+		IAction action = new NavigatePreviousSubWordAction();
+		action.setActionDefinitionId(ITextEditorActionDefinitionIds.WORD_PREVIOUS);
+		setAction(ITextEditorActionDefinitionIds.WORD_PREVIOUS, action);
+		textWidget.setKeyBinding(SWT.CTRL | SWT.ARROW_LEFT, SWT.NULL);
+
+		action = new NavigateNextSubWordAction();
+		action.setActionDefinitionId(ITextEditorActionDefinitionIds.WORD_NEXT);
+		setAction(ITextEditorActionDefinitionIds.WORD_NEXT, action);
+		textWidget.setKeyBinding(SWT.CTRL | SWT.ARROW_RIGHT, SWT.NULL);
+
+		action = new SelectPreviousSubWordAction();
+		action.setActionDefinitionId(ITextEditorActionDefinitionIds.SELECT_WORD_PREVIOUS);
+		setAction(ITextEditorActionDefinitionIds.SELECT_WORD_PREVIOUS, action);
+		textWidget.setKeyBinding(SWT.CTRL | SWT.SHIFT | SWT.ARROW_LEFT, SWT.NULL);
+
+		action = new SelectNextSubWordAction();
+		action.setActionDefinitionId(ITextEditorActionDefinitionIds.SELECT_WORD_NEXT);
+		setAction(ITextEditorActionDefinitionIds.SELECT_WORD_NEXT, action);
+		textWidget.setKeyBinding(SWT.CTRL | SWT.SHIFT | SWT.ARROW_RIGHT, SWT.NULL);
+
+		action = new DeletePreviousSubWordAction();
+		action.setActionDefinitionId(ITextEditorActionDefinitionIds.DELETE_PREVIOUS_WORD);
+		setAction(ITextEditorActionDefinitionIds.DELETE_PREVIOUS_WORD, action);
+		textWidget.setKeyBinding(SWT.CTRL | SWT.BS, SWT.NULL);
+		markAsStateDependentAction(ITextEditorActionDefinitionIds.DELETE_PREVIOUS_WORD, true);
+
+		action = new DeleteNextSubWordAction();
+		action.setActionDefinitionId(ITextEditorActionDefinitionIds.DELETE_NEXT_WORD);
+		setAction(ITextEditorActionDefinitionIds.DELETE_NEXT_WORD, action);
+		textWidget.setKeyBinding(SWT.CTRL | SWT.DEL, SWT.NULL);
+		markAsStateDependentAction(ITextEditorActionDefinitionIds.DELETE_NEXT_WORD, true);
+	}
 
 	@Override
 	protected void initializeKeyBindingScopes() {
@@ -55,6 +497,22 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 			editorComposite = parent;
 		}
 		return editorComposite;
+	}
+
+	private boolean getOptionEnableSubWordNavigation() {
+		EditorConfiguration configuration = PlatformUI.getWorkbench().getService(EditorConfiguration.class);
+		if (configuration == null) {
+			return false;
+		}
+
+		EditorOptions options = null;
+		IWorkspace workspace = PlatformUI.getWorkbench().getService(IWorkspace.class);
+		options = configuration.options(workspace);
+
+		if (options == null) {
+			return false;
+		}
+		return options.enableSubWordNavigation();
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CLspEditor.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CLspEditor.java
@@ -45,7 +45,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 4.0
+	 * @since 3.0
 	 */
 	protected abstract class NextSubWordAction extends TextNavigationAction {
 		protected CWordIterator fIterator = new CWordIterator();
@@ -54,7 +54,6 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 		 * Creates a new next sub-word action.
 		 *
 		 * @param code Action code for the default operation. Must be an action code from @see org.eclipse.swt.custom.ST.
-		 * @since 4.0
 		 */
 		protected NextSubWordAction(int code) {
 			super(getSourceViewer().getTextWidget(), code);
@@ -120,7 +119,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 4.0
+	 * @since 3.0
 	 */
 	protected class NavigateNextSubWordAction extends NextSubWordAction {
 		/**
@@ -141,7 +140,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 4.0
+	 * @since 3.0
 	 */
 	protected class DeleteNextSubWordAction extends NextSubWordAction implements IUpdate {
 		/**
@@ -204,7 +203,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 4.0
+	 * @since 3.0
 	 */
 	protected class SelectNextSubWordAction extends NextSubWordAction {
 		/**
@@ -238,7 +237,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 4.0
+	 * @since 3.0
 	 */
 	protected abstract class PreviousSubWordAction extends TextNavigationAction {
 		protected CWordIterator fIterator = new CWordIterator();
@@ -312,7 +311,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 4.0
+	 * @since 3.0
 	 */
 	protected class NavigatePreviousSubWordAction extends PreviousSubWordAction {
 
@@ -334,7 +333,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 4.0
+	 * @since 3.0
 	 */
 	protected class DeletePreviousSubWordAction extends PreviousSubWordAction implements IUpdate {
 		/**
@@ -395,7 +394,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 4.0
+	 * @since 3.0
 	 */
 	protected class SelectPreviousSubWordAction extends PreviousSubWordAction {
 		/**

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CLspEditor.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/CLspEditor.java
@@ -45,7 +45,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	protected abstract class NextSubWordAction extends TextNavigationAction {
 		protected CWordIterator fIterator = new CWordIterator();
@@ -119,7 +119,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	protected class NavigateNextSubWordAction extends NextSubWordAction {
 		/**
@@ -140,7 +140,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	protected class DeleteNextSubWordAction extends NextSubWordAction implements IUpdate {
 		/**
@@ -203,7 +203,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	protected class SelectNextSubWordAction extends NextSubWordAction {
 		/**
@@ -237,7 +237,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	protected abstract class PreviousSubWordAction extends TextNavigationAction {
 		protected CWordIterator fIterator = new CWordIterator();
@@ -311,7 +311,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	protected class NavigatePreviousSubWordAction extends PreviousSubWordAction {
 
@@ -333,7 +333,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	protected class DeletePreviousSubWordAction extends PreviousSubWordAction implements IUpdate {
 		/**
@@ -394,7 +394,7 @@ public class CLspEditor extends ExtensionBasedTextEditor {
 	 *
 	 * copied from org.eclipse.cdt.internal.ui.editor.CEditor
 	 *
-	 * @since 3.0
+	 * @since 3.1
 	 */
 	protected class SelectPreviousSubWordAction extends PreviousSubWordAction {
 		/**

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/EditorPreferredOptions.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/editor/EditorPreferredOptions.java
@@ -39,6 +39,11 @@ public final class EditorPreferredOptions extends PreferredOptions implements Ed
 	}
 
 	@Override
+	public boolean enableSubWordNavigation() {
+		return booleanValue(EditorMetadata.Predefined.enableSubWordNavigation);
+	}
+
+	@Override
 	public boolean formatOnSave() {
 		return booleanValue(EditorMetadata.Predefined.formatOnSave);
 	}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Bachmann electronic GmbH and others.
+ * Copyright (c) 2023, 2025 Bachmann electronic GmbH and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,6 +36,9 @@ public class LspUiMessages extends NLS {
 	public static String LspEditorConfigurationPage_preferLspEditor_description;
 	public static String LspEditorConfigurationPage_showTryLspBanner;
 	public static String LspEditorConfigurationPage_showTryLspBanner_description;
+	public static String LspEditorConfigurationPage_gneral_behavior_group;
+	public static String LspEditorConfigurationPage_enableSubWordNavigation;
+	public static String LspEditorConfigurationPage_enableSubWordNavigation_description;
 
 	public static String SaveActionsConfigurationPage_FormatSourceCode;
 	public static String SaveActionsConfigurationPage_FormatSourceCode_description;

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.properties
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/messages/LspUiMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2023 Eclipse Foundation and others
+# Copyright (c) 2023, 2025 Eclipse Foundation and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -24,6 +24,9 @@ LspEditorConfigurationPage_preferLspEditor=Set C/C++ Editor (LSP) as default
 LspEditorConfigurationPage_preferLspEditor_description=The language server based C/C++ Editor will be used to open C/C++ source files.
 LspEditorConfigurationPage_showTryLspBanner=Show the editing experience banner
 LspEditorConfigurationPage_showTryLspBanner_description=Show the try the new editing experience banner when opening C/C++ editors
+LspEditorConfigurationPage_gneral_behavior_group=General behavior
+LspEditorConfigurationPage_enableSubWordNavigation=Smart &caret positioning in identifiers
+LspEditorConfigurationPage_enableSubWordNavigation_description=Enables smart caret positioning within camelCase and snake_case identifiers when navigating with arrow keys.
 
 SaveActionsConfigurationPage_FormatSourceCode=Format source code
 SaveActionsConfigurationPage_FormatSourceCode_description=Formats source code when file is saved

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/EditorConfigurationArea.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/EditorConfigurationArea.java
@@ -18,8 +18,10 @@ import java.util.List;
 import org.eclipse.cdt.lsp.editor.ConfigurationVisibility;
 import org.eclipse.cdt.lsp.editor.EditorMetadata;
 import org.eclipse.cdt.lsp.editor.EditorOptions;
+import org.eclipse.cdt.lsp.internal.messages.LspUiMessages;
 import org.eclipse.cdt.lsp.ui.ConfigurationArea;
 import org.eclipse.cdt.lsp.ui.EditorConfigurationPage;
+import org.eclipse.cdt.utils.ui.controls.ControlFactory;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.OsgiPreferenceMetadataStore;
 import org.eclipse.jface.layout.GridLayoutFactory;
@@ -33,6 +35,7 @@ public final class EditorConfigurationArea extends ConfigurationArea<EditorOptio
 
 	private final Button prefer;
 	private final Button showBanner;
+	private final Button enableSubWordNavigation;
 	private ConfigurationVisibility visibility;
 
 	public EditorConfigurationArea(Composite parent, boolean isProjectScope) {
@@ -52,6 +55,13 @@ public final class EditorConfigurationArea extends ConfigurationArea<EditorOptio
 			this.prefer = null;
 			this.showBanner = null;
 		}
+		this.enableSubWordNavigation = isProjectScope ? null : createSubWordNavigationButton(composite);
+	}
+
+	private Button createSubWordNavigationButton(Composite parent) {
+		Composite behaviorComposite = ControlFactory.createGroup(parent,
+				LspUiMessages.LspEditorConfigurationPage_gneral_behavior_group, 1);
+		return createButton(EditorMetadata.Predefined.enableSubWordNavigation, behaviorComposite, SWT.CHECK, 0);
 	}
 
 	@Override
@@ -69,6 +79,9 @@ public final class EditorConfigurationArea extends ConfigurationArea<EditorOptio
 		if (showBanner != null) {
 			showBanner.setSelection(options.showTryLspBanner());
 			showBanner.setEnabled(enable);
+		}
+		if (enableSubWordNavigation != null) {
+			enableSubWordNavigation.setSelection(options.enableSubWordNavigation());
 		}
 	}
 


### PR DESCRIPTION
- The relevant editor actions have been copied from CEditor to not introduce a dependency on certain CDT version in CDT-LSP since the code is not accessible from CDT-LSP (sub classes in CEditor).

fixes #561