### PR TITLE
Improve triggering of license checks

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,19 +1,20 @@
 # This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
 
-name: License vetting status check
+name: License check
 
 on:
   push:
-    branches: 
-      - 'main'
   pull_request:
-    branches: 
-     - 'main'
+    paths:
+    - '**/pom.xml'
+    - '**/*.target'
+    - '.github/workflows/licensecheck.yml'
   issue_comment:
     types: [created]
 
 jobs:
-  call-license-check:
+  call:
+    if: github.event_name == 'pull_request' || github.event_name == 'issue_comment' || github.repository_owner == 'eclipse-cdt'
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: tools.cdt


### PR DESCRIPTION
License checks fail a lot due to rate limiting, and we often run license checks on PRs that aren't changing dependencies, which mean they *shouldn't* change license check.

Therefore only run license check if pom.xml/*.target files change on a PR. For pushes, run the license check always so that we can always see that the latest HEAD commit still is properly licensed.

Additionally, run on all push branches, but limit the runs to the origin eclipse-cdt owned repos.

This sycnchronizes with the same changes made to cdt in https://github.com/eclipse-cdt/cdt/pull/1388