### PR TITLE
Customize C/C++ destructor symbol overlay icons in outline view (fix #608)

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.test/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.eclipse.cdt.lsp.test;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse.org
 Fragment-Host: org.eclipse.cdt.lsp
-Require-Bundle: junit-jupiter-api
+Require-Bundle: junit-jupiter-api,
+ junit-jupiter-params
 Automatic-Module-Name: org.eclipse.cdt.lsp.test
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/internal/ui/navigator/CSymbolIconProviderTest.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/internal/ui/navigator/CSymbolIconProviderTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Advantest GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dietrich Travkin (Solunar GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.test.internal.ui.navigator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.List;
+
+import org.eclipse.cdt.lsp.plugin.LspPlugin;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.lsp4e.outline.SymbolsLabelProvider;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
+import org.eclipse.lsp4e.ui.LSPImages;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
+import org.eclipse.swt.graphics.Image;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class CSymbolIconProviderTest {
+
+	@ParameterizedTest
+	@CsvSource({
+	// @formatter:off
+		"~SomeType, true",
+		"SomeType, false",
+		"SomeType::~SomeType, true",
+		"SomeType::SomeType, false"
+	// @formatter:on
+	})
+	public void testCustomDestructorOverlayIconUsed(String symbolName, boolean isDestructor) {
+		DocumentSymbol documentSymbol = new DocumentSymbol();
+
+		// LSP doesn't know destructors, they are modelled as constructors with a ~ in their name
+		documentSymbol.setKind(SymbolKind.Constructor);
+
+		documentSymbol.setName(symbolName);
+		documentSymbol.setTags(List.of(SymbolTag.Public));
+		DocumentSymbolWithURI symbol = new DocumentSymbolWithURI(documentSymbol,
+				URI.create("file:///home/username/some/path/SomeType.cpp"));
+		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider();
+
+		ImageDescriptor topRightOverlay;
+		if (isDestructor) {
+			topRightOverlay = LspPlugin.getDefault().getImageDescriptor(LspPlugin.IMG_OVR_DESTRUCTOR);
+		} else {
+			topRightOverlay = LSPImages.getImageDescriptor(LSPImages.IMG_OVR_CONSTRUCTOR);
+		}
+		Image expectedImage = LSPImages.getImageWithOverlays(
+				// base image for a public method
+				LSPImages.IMG_METHOD_VIS_PUBLIC,
+				// no overlay icons except of our destructor overlay in the top right corner
+				null, topRightOverlay, null, null, null);
+
+		Image actualImage = labelProvider.getImage(symbol);
+
+		assertEquals(expectedImage, actualImage);
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/internal/ui/navigator/CSymbolIconProviderTest.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/internal/ui/navigator/CSymbolIconProviderTest.java
@@ -40,6 +40,7 @@ public class CSymbolIconProviderTest {
 	// @formatter:on
 	})
 	public void testCustomDestructorOverlayIconUsed(String symbolName, boolean isDestructor) {
+		// GIVEN a document symbol representing a public destructor or constructor
 		DocumentSymbol documentSymbol = new DocumentSymbol();
 
 		// LSP doesn't know destructors, they are modelled as constructors with a ~ in their name
@@ -49,8 +50,13 @@ public class CSymbolIconProviderTest {
 		documentSymbol.setTags(List.of(SymbolTag.Public));
 		DocumentSymbolWithURI symbol = new DocumentSymbolWithURI(documentSymbol,
 				URI.create("file:///home/username/some/path/SomeType.cpp"));
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider();
 
+		// WHEN we get an image with overlay icons from the label provider for our destructor/constructor symbol
+		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider();
+		Image actualImage = labelProvider.getImage(symbol);
+
+		// THEN we expect the image to represent a public method (base image)
+		// with a destructor/constructor overlay icon in the top-right corner
 		ImageDescriptor topRightOverlay;
 		if (isDestructor) {
 			topRightOverlay = LspPlugin.getDefault().getImageDescriptor(LspPlugin.IMG_OVR_DESTRUCTOR);
@@ -62,8 +68,6 @@ public class CSymbolIconProviderTest {
 				LSPImages.IMG_METHOD_VIS_PUBLIC,
 				// no overlay icons except of our destructor overlay in the top right corner
 				null, topRightOverlay, null, null, null);
-
-		Image actualImage = labelProvider.getImage(symbol);
 
 		assertEquals(expectedImage, actualImage);
 	}

--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Bundle-Activator: org.eclipse.cdt.lsp.plugin.LspPlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.lsp4e;bundle-version="0.19.10",
+ org.eclipse.lsp4e;bundle-version="0.19.11",
  org.eclipse.tm4e.ui,
  org.eclipse.tm4e.languageconfiguration,
  org.eclipse.ui.genericeditor,

--- a/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Bundle-Activator: org.eclipse.cdt.lsp.plugin.LspPlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.lsp4e;bundle-version="0.18.14",
+ org.eclipse.lsp4e;bundle-version="0.19.10",
  org.eclipse.tm4e.ui,
  org.eclipse.tm4e.languageconfiguration,
  org.eclipse.ui.genericeditor,

--- a/bundles/org.eclipse.cdt.lsp/icons/ovr16/destr_ovr.svg
+++ b/bundles/org.eclipse.cdt.lsp/icons/ovr16/destr_ovr.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="destr_ovr.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="2.670023"
+     inkscape:cy="-9.4804096"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1264"
+     inkscape:window-height="1020"
+     inkscape:window-x="986"
+     inkscape:window-y="446"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+    <inkscape:page
+       x="0"
+       y="0"
+       width="7"
+       height="8"
+       id="page2"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1044.3622)">
+    <ellipse
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="path3351"
+       cx="3.4709821"
+       cy="1050.2751"
+       rx="2.4665179"
+       ry="1.0825893" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0.99437055,1044.3441 c 0,0 0.0262225,6.1581 0,6.0609 -0.0262225,-0.097 5.00707565,0 5.00707565,0 v -6.029 z"
+       id="path3350"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="csscccc"
+       inkscape:connector-curvature="0"
+       id="path4163-4-0"
+       d="m 5.47583,1049.3058 v 0.5002 c 0,0 -0.5325989,1.0498 -1.5061289,1.0498 H 2.7811646 c -0.5159588,0 -1.2773243,0.043 -1.2773243,-0.115 l 0.00392,-1.501 v -0.8854"
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.01003;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       id="g4195">
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 6.0379464,1048.8912 c 0,0 -0.9375,0.904 -1.2165178,0.904 -0.2790179,0 -1.3727679,-0.011 -1.5848215,-0.1897 -0.2120535,-0.1786 -0.7589285,-1.0045 -0.7700893,-1.0603 -0.011161,-0.056 0.15625,-2.5781 0.1674108,-2.7455 0.011161,-0.1674 0.4241071,-0.8817 0.4910714,-0.8817 0.066964,0 1.4955357,0.078 1.5513393,0.089 0.055803,0.011 0.9151785,0.6809 0.9151785,0.6809 l 0.4352679,0.1898 z"
+         id="path4220"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccsssccc" />
+    </g>
+    <path
+       style="fill:none;stroke:#df4848;stroke-width:0.902127px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.4749083,1049.8753 0.040535,-5.0492 1.5606532,-0.026 c 1.7025303,0.052 1.6214579,2.641 1.6214579,2.641 0,0 0.1216097,2.4856 -1.5809207,2.4597 z"
+       id="path1-6"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:none;stroke:#9d0808;stroke-width:0.896326px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 2.3850227,1049.8987 0.03997,-5.0548 1.538893,-0.026 c 1.678792,0.052 1.59885,2.644 1.59885,2.644 0,0 0.119914,2.4884 -1.558878,2.4625 z"
+       id="path1"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -84,8 +84,8 @@
    </extension>
    <extension
          point="org.eclipse.tm4e.registry.grammars">
-      <!-- This content type binding is needed because the cpp content type from TM4E (source.cpp) 
-      does not cover C++ standard library header without file extension -->         
+      <!-- This content type binding is needed because the cpp content type from TM4E (source.cpp)
+      does not cover C++ standard library header without file extension -->
       <scopeNameContentTypeBinding
             contentTypeId="org.eclipse.cdt.core.cxxHeader"
             scopeName="source.cpp">
@@ -166,7 +166,7 @@
                 value="org.eclipse.lsp4e.outline.SymbolsModel$DocumentSymbolWithURI">
           </instanceof>
 			</or>
-         </enablement>			
+         </enablement>
        </actionProvider>
     <commonSorter
           class="org.eclipse.lsp4e.outline.OutlineSorter"
@@ -184,6 +184,22 @@
             </contentExtension>
          </includes>
       </viewerContentBinding>
+   </extension>
+   <extension
+         point="org.eclipse.lsp4e.symbolIconsProvider">
+      <iconProvider
+            class="org.eclipse.cdt.lsp.internal.ui.navigator.CSymbolIconProvider"
+            id="org.eclipse.cdt.lsp.symbolIconProvider">
+         <contentType
+               contentTypeId="org.eclipse.cdt.core.cSource">
+         </contentType>
+         <contentType
+               contentTypeId="org.eclipse.cdt.core.cxxSource">
+         </contentType>
+         <contentType
+               contentTypeId="org.eclipse.cdt.core.cxxHeader">
+         </contentType>
+      </iconProvider>
    </extension>
    <extension
          point="org.eclipse.core.contenttype.contentTypes">
@@ -220,7 +236,7 @@
 	                property="org.eclipse.cdt.lsp.server.enable.hasLanguageServer"
 	                value="true">
 		            </test>
-	            </with>        
+	            </with>
       </definition>
    </extension>
    <extension
@@ -328,7 +344,7 @@
          </action>
       </viewerContribution>
    </extension>
-   
+
    <extension
          point="org.eclipse.ui.genericeditor.hoverProviders">
       <hoverProvider
@@ -360,7 +376,7 @@
 	      <keywordReference id="org.eclipse.cdt.ui.saveactions"/>
 	      <keywordReference id="org.eclipse.cdt.ui.common"/>
 	      <keywordReference id="org.eclipse.cdt.ui.ceditor"/>
-      </page>      
+      </page>
    </extension>
    <extension
          point="org.eclipse.ui.propertyPages">
@@ -396,7 +412,7 @@
                 type="org.eclipse.core.resources.IProject">
           </adapt>
        </enabledWhen>
-      </page>      
+      </page>
    </extension>
    <extension
          point="org.eclipse.ui.genericeditor.reconcilers">
@@ -447,6 +463,6 @@
             name="%CEditor.name"
             parentId="org.eclipse.ui.genericeditor.genericEditorContext">
       </context>
-   </extension>  
+   </extension>
 </plugin>
 

--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -191,9 +191,6 @@
             class="org.eclipse.cdt.lsp.internal.ui.navigator.CSymbolIconProvider"
             id="org.eclipse.cdt.lsp.symbolIconProvider">
          <contentType
-               contentTypeId="org.eclipse.cdt.core.cSource">
-         </contentType>
-         <contentType
                contentTypeId="org.eclipse.cdt.core.cxxSource">
          </contentType>
          <contentType

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/navigator/CSymbolIconProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/navigator/CSymbolIconProvider.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Advantest GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dietrich Travkin (Solunar GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.cdt.lsp.internal.ui.navigator;
+
+import java.util.List;
+
+import org.eclipse.cdt.lsp.plugin.LspPlugin;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.lsp4e.ui.SymbolIconProvider;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
+
+public class CSymbolIconProvider extends SymbolIconProvider {
+
+	@Override
+	protected Overlays getOverlaysFor(final SymbolKind symbolKind, final List<SymbolTag> symbolTags, int severity,
+			Object symbol) {
+
+		final var overlays = super.getOverlaysFor(symbolKind, symbolTags, severity, symbol);
+
+		if (symbolKind == SymbolKind.Constructor) {
+			String name = getName(symbol);
+			// if the symbol's name represents a destructor, e.g. is named MyType::~MyType
+			if (name != null && name.contains("~")) { //$NON-NLS-1$
+				// then replace the constructor overlay with a destructor overlay
+				ImageDescriptor destructorOverlayDescriptor = LspPlugin.getDefault()
+						.getImageDescriptor(LspPlugin.IMG_OVR_DESTRUCTOR);
+				return new Overlays(overlays.topLeft, destructorOverlayDescriptor, overlays.bottomLeft,
+						overlays.bottomRight, overlays.underlay);
+			}
+		}
+
+		return overlays;
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/navigator/CSymbolIconProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/ui/navigator/CSymbolIconProvider.java
@@ -21,6 +21,15 @@ import org.eclipse.lsp4j.SymbolTag;
 
 public class CSymbolIconProvider extends SymbolIconProvider {
 
+	private static ImageDescriptor IMG_DESTRUCTOR_OVERLAY = null;
+
+	private ImageDescriptor getDestructorOverlay() {
+		if (IMG_DESTRUCTOR_OVERLAY == null) {
+			IMG_DESTRUCTOR_OVERLAY = LspPlugin.getDefault().getImageDescriptor(LspPlugin.IMG_OVR_DESTRUCTOR);
+		}
+		return IMG_DESTRUCTOR_OVERLAY;
+	}
+
 	@Override
 	protected Overlays getOverlaysFor(final SymbolKind symbolKind, final List<SymbolTag> symbolTags, int severity,
 			Object symbol) {
@@ -32,8 +41,7 @@ public class CSymbolIconProvider extends SymbolIconProvider {
 			// if the symbol's name represents a destructor, e.g. is named MyType::~MyType
 			if (name != null && name.contains("~")) { //$NON-NLS-1$
 				// then replace the constructor overlay with a destructor overlay
-				ImageDescriptor destructorOverlayDescriptor = LspPlugin.getDefault()
-						.getImageDescriptor(LspPlugin.IMG_OVR_DESTRUCTOR);
+				ImageDescriptor destructorOverlayDescriptor = getDestructorOverlay();
 				return new Overlays(overlays.topLeft, destructorOverlayDescriptor, overlays.bottomLeft,
 						overlays.bottomRight, overlays.underlay);
 			}

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/plugin/LspPlugin.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/plugin/LspPlugin.java
@@ -25,7 +25,6 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -109,10 +108,6 @@ public class LspPlugin extends AbstractUIPlugin {
 
 	public ImageDescriptor getImageDescriptor(String key) {
 		return getImageRegistry().getDescriptor(key);
-	}
-
-	public Image getImage(String key) {
-		return getImageRegistry().get(key);
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/plugin/LspPlugin.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/plugin/LspPlugin.java
@@ -13,13 +13,21 @@
 
 package org.eclipse.cdt.lsp.plugin;
 
+import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.cdt.lsp.internal.server.CLanguageServerEnableCache;
 import org.eclipse.cdt.lsp.internal.server.CLanguageServerRegistry;
 import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
 /**
@@ -31,6 +39,11 @@ public class LspPlugin extends AbstractUIPlugin {
 	public static final String PLUGIN_ID = "org.eclipse.cdt.lsp"; //$NON-NLS-1$
 	public static final String LSP_C_EDITOR_ID = "org.eclipse.cdt.lsp.CEditor"; //$NON-NLS-1$
 	public static final String C_EDITOR_ID = "org.eclipse.cdt.ui.editor.CEditor"; //$NON-NLS-1$
+
+	private static final String ICONS_PATH = "$nl$/icons/"; //$NON-NLS-1$
+	private static final String OVERLAY = ICONS_PATH + "ovr16/"; // overlay icons, size 7x8 //$NON-NLS-1$
+
+	public static final String IMG_OVR_DESTRUCTOR = "IMG_OVR_DESTRUCTOR"; //$NON-NLS-1$
 
 	// The shared instance
 	private static LspPlugin plugin;
@@ -75,6 +88,31 @@ public class LspPlugin extends AbstractUIPlugin {
 
 	public ICLanguageServerProvider getCLanguageServerProvider() {
 		return cLanguageServerProvider;
+	}
+
+	@Override
+	protected void initializeImageRegistry(ImageRegistry registry) {
+		Bundle bundle = Platform.getBundle(PLUGIN_ID);
+
+		if (bundle != null) {
+			registerImage(bundle, registry, IMG_OVR_DESTRUCTOR, OVERLAY + "destr_ovr.svg"); //$NON-NLS-1$
+		}
+	}
+
+	private static void registerImage(Bundle bundle, ImageRegistry registry, String imageKey, String imagePath) {
+		URL url = FileLocator.find(bundle, new Path(imagePath), null);
+		if (url != null) {
+			ImageDescriptor imageDescriptor = ImageDescriptor.createFromURL(url);
+			registry.put(imageKey, imageDescriptor);
+		}
+	}
+
+	public ImageDescriptor getImageDescriptor(String key) {
+		return getImageRegistry().getDescriptor(key);
+	}
+
+	public Image getImage(String key) {
+		return getImageRegistry().get(key);
 	}
 
 }


### PR DESCRIPTION
This PR should fix #608 by customizing the destructor overlay icon calculation in all relevant views. It is dependent on https://github.com/eclipse-lsp4e/lsp4e/pull/1521.