### PR TITLE
[releng] Include repo zip file in downloads

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,6 +78,7 @@ pipeline {
                   fi
                   $SSH mkdir -p ${DOWNLOAD_MOUNT}-new
                   $SCP -rp releng/org.eclipse.cdt.lsp.repository/target/repository/* "${SSHUSER}:"${DOWNLOAD_MOUNT}-new
+                  $SCP -rp releng/org.eclipse.cdt.lsp.repository/target/org.eclipse.cdt.lsp.repository.zip "${SSHUSER}:"${DOWNLOAD_MOUNT}-new
                   if $SSH test -e ${DOWNLOAD_MOUNT}; then
                       $SSH mv ${DOWNLOAD_MOUNT} ${DOWNLOAD_MOUNT}-last
                   fi


### PR DESCRIPTION
This normalizes with what happens in main CDT repo here[1]

[1] https://github.com/eclipse-cdt/cdt/blob/559c9a6a50d162aa0dacac61637b2ae923f72438/Jenkinsfile#L92