### PR TITLE
[releng] Include ci-and-git-info.txt in downloads

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,12 @@ pipeline {
                       -Dmaven.repo.local=/home/jenkins/.m2/repository \
                       --settings /home/jenkins/.m2/settings.xml \
                 '''
+                sh '''
+                  echo "TIMESTAMP: $(date)" > releng/org.eclipse.cdt.lsp.repository/target/repository/ci-and-git-info.txt
+                  echo "CI URL: ${BUILD_URL}" >> releng/org.eclipse.cdt.lsp.repository/target/repository/ci-and-git-info.txt
+                  echo "Most recent git commits: (output of  git log --graph --pretty='tformat:%h [%ci] - %s' -20)"  >> releng/org.eclipse.cdt.lsp.repository/target/repository/ci-and-git-info.txt
+                  git log --graph --pretty='tformat:%h [%ci] - %s' -20 | tee -a releng/org.eclipse.cdt.lsp.repository/target/repository/ci-and-git-info.txt
+                '''
               }
             }
           }


### PR DESCRIPTION
This normalizes with what happens in main CDT repo here[1]

[1] https://github.com/eclipse-cdt/cdt/blob/559c9a6a50d162aa0dacac61637b2ae923f72438/Jenkinsfile#L57-L62