### PR TITLE
[releng] stable URLs for 2026-06 on CDT LSP 3.6 branch

### DIFF
--- a/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
+++ b/releng/org.eclipse.cdt.lsp.target/org.eclipse.cdt.lsp.target.target
@@ -7,7 +7,7 @@
 			<unit id="org.eclipse.license.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260601-0713" />
+			<repository location="https://download.eclipse.org/eclipse/updates/4.40" />
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.jdt.annotation" version="0.0.0" />
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
@@ -19,7 +19,7 @@
 			<repository location="https://download.eclipse.org/mylyn/updates/release/latest/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/linuxtools/update-2026-06-docker-rc1" />
+			<repository location="https://download.eclipse.org/linuxtools/update-docker-5.23.0/" />
 			<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Synchronise the branch with cdt - see https://github.com/eclipse-cdt/cdt/pull/1477