### PR TITLE
fix: cache non-c content type on editor opening

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/internal/server/CLanguageServerEnableCacheTest.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/internal/server/CLanguageServerEnableCacheTest.java
@@ -28,7 +28,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.IEditorPart;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -155,14 +154,12 @@ class CLanguageServerEnableCacheTest {
 	}
 
 	@Test
-	@Disabled("See https://github.com/eclipse-cdt/cdt-lsp/issues/630")
 	@DisplayName("Cached non C file URI shall return false and should not be removed after closing")
 	public void testCache5() throws CoreException, IOException {
 		test_File_URIopenedInEditor(projectNoCFile.getFullPath().toFile().toURI());
 	}
 
 	@Test
-	@Disabled("See https://github.com/eclipse-cdt/cdt-lsp/issues/630")
 	@DisplayName("Cached EXTERNAL non C file URI shall return false and should not be removed after closing")
 	public void testCache6() throws CoreException, IOException {
 		test_File_URIopenedInEditor(externalNoCFile.toURI());

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/server/CLanguageServerEnableCache.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/internal/server/CLanguageServerEnableCache.java
@@ -175,17 +175,28 @@ public final class CLanguageServerEnableCache implements IContentTypeChangeListe
 
 	@Override
 	public void partOpened(IWorkbenchPart part) {
-		if (part instanceof ExtensionBasedTextEditor editor && LspUtils.checkForCContentType(editor.getEditorInput())) {
-			Optional.ofNullable(LSPEclipseUtils.toUri(editor.getEditorInput())).ifPresent(uri -> {
-				var hash = part.hashCode();
-				var data = cache.get(uri);
-				if (data != null) {
-					data.enable = true;
-					data.addEditor(hash);
-				} else {
-					cache.put(uri, new Data(true, hash));
-				}
-			});
+		if (part instanceof ExtensionBasedTextEditor editor) {
+			if (LspUtils.checkForCContentType(editor.getEditorInput())) {
+				Optional.ofNullable(LSPEclipseUtils.toUri(editor.getEditorInput())).ifPresent(uri -> {
+					var hash = part.hashCode();
+					var data = cache.get(uri);
+					if (data != null) {
+						data.enable = true;
+						data.addEditor(hash);
+					} else {
+						cache.put(uri, new Data(true, hash));
+					}
+				});
+			} else {
+				Optional.ofNullable(LSPEclipseUtils.toUri(editor.getEditorInput())).ifPresent(uri -> {
+					var data = cache.get(uri);
+					if (data != null) {
+						data.enable = false;
+					} else {
+						cache.put(uri, new Data(false));
+					}
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-cdt/cdt-lsp/issues/630